### PR TITLE
patch get_datapaths to use `dict.get`

### DIFF
--- a/dreem/io/config.py
+++ b/dreem/io/config.py
@@ -182,10 +182,17 @@ class Config:
         label_files = vid_files = None
 
         if dir_cfg:
-            labels_suff = dir_cfg.labels_suffix
-            vid_suff = dir_cfg.vid_suffix
-            labels_path = f"{dir_cfg.path}/*{labels_suff}"
-            vid_path = f"{dir_cfg.path}/*{vid_suff}"
+            labels_suff = dir_cfg.get("labels_suffix")
+            vid_suff = dir_cfg.get("vid_suffix")
+            if labels_suff is None or vid_suff is None:
+                raise KeyError(
+                    f"Must provide a labels suffix and vid suffix to search for but found {labels_suff} and {vid_suff}!"
+                )
+            dir_path = dir_cfg.get("path", ".")
+            logger.debug(f"Searching `{dir_path}` directory")
+
+            labels_path = f"{dir_path}/*{labels_suff}"
+            vid_path = f"{dir_path}/*{vid_suff}"
             logger.debug(f"Searching for labels matching {labels_path}")
             label_files = glob.glob(labels_path)
             logger.debug(f"Searching for videos matching {vid_path}")


### PR DESCRIPTION
As noted in #89, I missed some subdictionaries using `cfg.param` syntax instead of `cfg.get("param")` I went thru and checked `dreem.io.Config` to make sure this doesnt happen and added some tests so it should hopefully be fine now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced robustness of the data path retrieval method, requiring both `labels_suffix` and `vid_suffix` for better configuration handling.
  
- **Bug Fixes**
	- Improved error handling for missing configuration suffixes, ensuring clearer feedback on configuration issues.

- **Tests**
	- Updated test suite to include additional checks for dataset configurations, ensuring accurate validation of the `Config` class functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->