### PR TITLE
Mustafa multiple data paths

### DIFF
--- a/dreem/io/config.py
+++ b/dreem/io/config.py
@@ -190,15 +190,21 @@ class Config:
                 raise KeyError(
                     f"Must provide a labels suffix and vid suffix to search for but found {labels_suff} and {vid_suff}!"
                 )
-            dir_path = dir_cfg.get("path", ".")
-            logger.debug(f"Searching `{dir_path}` directory")
+            list_dir_path = dir_cfg.get("path", ".")
+            if isinstance(list_dir_path, str):
+                list_dir_path = [list_dir_path]
+            label_files = []
+            vid_files = []
+            for dir_path in list_dir_path:
+                logger.debug(f"Searching `{dir_path}` directory")
 
-            labels_path = f"{dir_path}/*{labels_suff}"
-            vid_path = f"{dir_path}/*{vid_suff}"
-            logger.debug(f"Searching for labels matching {labels_path}")
-            label_files = glob.glob(labels_path)
-            logger.debug(f"Searching for videos matching {vid_path}")
-            vid_files = glob.glob(vid_path)
+                labels_path = f"{dir_path}/*{labels_suff}"
+                vid_path = f"{dir_path}/*{vid_suff}"
+                logger.debug(f"Searching for labels matching {labels_path}")
+                label_files.extend(glob.glob(labels_path))
+                logger.debug(f"Searching for videos matching {vid_path}")
+                vid_files.extend(glob.glob(vid_path))
+
             logger.debug(f"Found {len(label_files)} labels and {len(vid_files)} videos")
 
         else:

--- a/dreem/io/config.py
+++ b/dreem/io/config.py
@@ -191,7 +191,7 @@ class Config:
                     f"Must provide a labels suffix and vid suffix to search for but found {labels_suff} and {vid_suff}!"
                 )
             list_dir_path = dir_cfg.get("path", ".")
-            if isinstance(list_dir_path, str):
+            if not isinstance(list_dir_path, list):
                 list_dir_path = [list_dir_path]
             label_files = []
             vid_files = []


### PR DESCRIPTION
- Currently, we can only specify either a list of individual slp/mp4 files, or a single directory in which all the train/val data resides
- This PR adds support for specifying a list of directories for train/val data in the configs. This makes it easier to train on multiple datasets that may not be in the same directory
- Maintains backward compatibility in case a list is not specified i.e. if a single directory is provided

Old:

dataset:
  train_dataset:
    dir:
        path: "/root/vast/mustafa/lysosomes-airyscan-proofread/train-leave-out-7-1"

New:

dataset:
  train_dataset:
    dir:
        path: ["/root/vast/mustafa/lysosomes-airyscan-proofread/train-leave-out-7-1",
              "/root/talmolab-smb/datasets/mot/animal/sleap/btc/large_run/als/train"]