### PR TITLE
Mustafa multiple crop size

### DIFF
--- a/dreem/datasets/base_dataset.py
+++ b/dreem/datasets/base_dataset.py
@@ -3,6 +3,7 @@
 from dreem.datasets import data_utils
 from dreem.io import Frame
 from torch.utils.data import Dataset
+from typing import Union
 import numpy as np
 import torch
 
@@ -15,7 +16,7 @@ class BaseDataset(Dataset):
         label_files: list[str],
         vid_files: list[str],
         padding: int,
-        crop_size: int,
+        crop_size: Union[int, list[int]],
         chunk: bool,
         clip_length: int,
         mode: str,

--- a/dreem/datasets/sleap_dataset.py
+++ b/dreem/datasets/sleap_dataset.py
@@ -82,7 +82,9 @@ class SleapDataset(BaseDataset):
         )
 
         self.slp_files = slp_files
-        self.data_dirs = data_dirs # empty list, list of paths, or string of single path
+        self.data_dirs = (
+            data_dirs  # empty list, list of paths, or string of single path
+        )
         self.video_files = video_files
         self.padding = padding
         self.crop_size = crop_size
@@ -99,24 +101,24 @@ class SleapDataset(BaseDataset):
             self.anchors = [anchors]
         else:
             self.anchors = anchors
-        
-        
+
         if not isinstance(self.data_dirs, list):
             self.data_dirs = [self.data_dirs]
 
         if not isinstance(self.crop_size, list):
             # make a list so its handled consistently if multiple crops are used
-            if len(self.data_dirs) > 0: # for test mode, data_dirs is []
+            if len(self.data_dirs) > 0:  # for test mode, data_dirs is []
                 self.crop_size = [self.crop_size] * len(self.data_dirs)
             else:
                 self.crop_size = [self.crop_size]
 
-
         if len(self.data_dirs) > 0 and len(self.crop_size) != len(self.data_dirs):
-            raise ValueError(f"If a list of crop sizes or data directories are given,"
-                             f"they must have the same length but got {len(self.crop_size)} "
-                             f"and {len(self.data_dirs)}")
-            
+            raise ValueError(
+                f"If a list of crop sizes or data directories are given,"
+                f"they must have the same length but got {len(self.crop_size)} "
+                f"and {len(self.data_dirs)}"
+            )
+
         if (
             isinstance(self.anchors, list) and len(self.anchors) == 0
         ) or self.anchors == 0:

--- a/dreem/datasets/sleap_dataset.py
+++ b/dreem/datasets/sleap_dataset.py
@@ -38,39 +38,39 @@ class SleapDataset(BaseDataset):
     ):
         """Initialize SleapDataset.
 
-                Args:
-                    slp_files: a list of .slp files storing tracking annotations
-                    video_files: a list of paths to video files
-                    data_dirs: a path, or a list of paths to data directories. If provided, crop_size should be a list of integers
-                        with the same length as data_dirs.
-                    padding: amount of padding around object crops
-                    crop_size: the size of the object crops. Can be either:
-        +                - An integer specifying a single crop size for all objects
-        +                - A list of integers specifying different crop sizes for different data directories
-                    anchors: One of:
-                                * a string indicating a single node to center crops around
-                                * a list of skeleton node names to be used as the center of crops
-                                * an int indicating the number of anchors to randomly select
-                            If unavailable then crop around the midpoint between all visible anchors.
-                    chunk: whether or not to chunk the dataset into batches
-                    clip_length: the number of frames in each chunk
-                    mode: `train`, `val`, or `test`. Determines whether this dataset is used for
-                        training, validation/testing/inference.
-                    handle_missing: how to handle missing single nodes. one of `["drop", "ignore", "centroid"]`.
-                                    if "drop" then we dont include instances which are missing the `anchor`.
-                                    if "ignore" then we use a mask instead of a crop and nan centroids/bboxes.
-                                    if "centroid" then we default to the pose centroid as the node to crop around.
-                    augmentations: An optional dict mapping augmentations to parameters. The keys
-                        should map directly to augmentation classes in albumentations. Example:
-                            augmentations = {
-                                'Rotate': {'limit': [-90, 90], 'p': 0.5},
-                                'GaussianBlur': {'blur_limit': (3, 7), 'sigma_limit': 0, 'p': 0.2},
-                                'RandomContrast': {'limit': 0.2, 'p': 0.6}
-                            }
-                    n_chunks: Number of chunks to subsample from.
-                        Can either a fraction of the dataset (ie (0,1.0]) or number of chunks
-                    seed: set a seed for reproducibility
-                    verbose: boolean representing whether to print
+        Args:
+            slp_files: a list of .slp files storing tracking annotations
+            video_files: a list of paths to video files
+            data_dirs: a path, or a list of paths to data directories. If provided, crop_size should be a list of integers
+                with the same length as data_dirs.
+            padding: amount of padding around object crops
+            crop_size: the size of the object crops. Can be either:
+                - An integer specifying a single crop size for all objects
+                - A list of integers specifying different crop sizes for different data directories
+            anchors: One of:
+                        * a string indicating a single node to center crops around
+                        * a list of skeleton node names to be used as the center of crops
+                        * an int indicating the number of anchors to randomly select
+                    If unavailable then crop around the midpoint between all visible anchors.
+            chunk: whether or not to chunk the dataset into batches
+            clip_length: the number of frames in each chunk
+            mode: `train`, `val`, or `test`. Determines whether this dataset is used for
+                training, validation/testing/inference.
+            handle_missing: how to handle missing single nodes. one of `["drop", "ignore", "centroid"]`.
+                            if "drop" then we dont include instances which are missing the `anchor`.
+                            if "ignore" then we use a mask instead of a crop and nan centroids/bboxes.
+                            if "centroid" then we default to the pose centroid as the node to crop around.
+            augmentations: An optional dict mapping augmentations to parameters. The keys
+                should map directly to augmentation classes in albumentations. Example:
+                    augmentations = {
+                        'Rotate': {'limit': [-90, 90], 'p': 0.5},
+                        'GaussianBlur': {'blur_limit': (3, 7), 'sigma_limit': 0, 'p': 0.2},
+                        'RandomContrast': {'limit': 0.2, 'p': 0.6}
+                    }
+            n_chunks: Number of chunks to subsample from.
+                Can either a fraction of the dataset (ie (0,1.0]) or number of chunks
+            seed: set a seed for reproducibility
+            verbose: boolean representing whether to print
         """
         super().__init__(
             slp_files,
@@ -172,12 +172,11 @@ class SleapDataset(BaseDataset):
         # get the correct crop size based on the video
         video_par_path = Path(video_name).parent
         if len(self.data_dirs) > 0:
+            crop_size = self.crop_size[0]
             for j, data_dir in enumerate(self.data_dirs):
                 if Path(data_dir) == video_par_path:
                     crop_size = self.crop_size[j]
                     break
-                else:
-                    crop_size = self.crop_size[0]
         else:
             crop_size = self.crop_size[0]
 

--- a/dreem/inference/eval.py
+++ b/dreem/inference/eval.py
@@ -52,7 +52,7 @@ def run(cfg: DictConfig) -> dict[int, sio.Labels]:
         "persistent_tracking", False
     )
     logger.info(f"Computing the following metrics:")
-    logger.info(model.metrics.test)
+    logger.info(model.metrics['test'])
     model.test_results["save_path"] = eval_cfg.cfg.runner.save_path
     logger.info(f"Saving results to {model.test_results['save_path']}")
 

--- a/dreem/inference/eval.py
+++ b/dreem/inference/eval.py
@@ -52,7 +52,7 @@ def run(cfg: DictConfig) -> dict[int, sio.Labels]:
         "persistent_tracking", False
     )
     logger.info(f"Computing the following metrics:")
-    logger.info(model.metrics['test'])
+    logger.info(model.metrics["test"])
     model.test_results["save_path"] = eval_cfg.cfg.runner.save_path
     logger.info(f"Saving results to {model.test_results['save_path']}")
 

--- a/dreem/io/config.py
+++ b/dreem/io/config.py
@@ -513,7 +513,9 @@ class Config:
             if profiler in map_profiler:
                 profiler = map_profiler[profiler](filename="profile")
             else:
-                raise ValueError(f"Profiler {profiler} not supported! Please use one of {list(map_profiler.keys())}")
+                raise ValueError(
+                    f"Profiler {profiler} not supported! Please use one of {list(map_profiler.keys())}"
+                )
 
         return pl.Trainer(
             callbacks=callbacks,

--- a/dreem/io/config.py
+++ b/dreem/io/config.py
@@ -501,8 +501,19 @@ class Config:
         if "devices" not in trainer_params:
             trainer_params["devices"] = devices
 
+        map_profiler = {
+            "advanced": pl.profilers.AdvancedProfiler,
+            "simple": pl.profilers.SimpleProfiler,
+            "pytorch": pl.profilers.PyTorchProfiler,
+            "passthrough": pl.profilers.PassThroughProfiler,
+            "xla": pl.profilers.XLAProfiler,
+        }
+
         if profiler:
-            profiler = pl.profilers.AdvancedProfiler(filename="profile.txt")
+            if profiler in map_profiler:
+                profiler = map_profiler[profiler](filename="profile")
+            else:
+                raise ValueError(f"Profiler {profiler} not supported! Please use one of {list(map_profiler.keys())}")
 
         return pl.Trainer(
             callbacks=callbacks,

--- a/dreem/io/config.py
+++ b/dreem/io/config.py
@@ -180,7 +180,6 @@ class Config:
             lists of labels file paths and video file paths respectively
         """
         dir_cfg = data_cfg.pop("dir", None)
-
         label_files = vid_files = None
 
         if dir_cfg:
@@ -253,6 +252,12 @@ class Config:
             raise ValueError(
                 "`mode` must be one of ['train', 'val','test'], not '{mode}'"
             )
+
+        if "dir" in dataset_params:
+            self.data_dirs = dataset_params["dir"]["path"]
+        else:
+            self.data_dirs = []
+
         if label_files is None or vid_files is None:
             label_files, vid_files = self.get_data_paths(dataset_params)
         # todo: handle this better
@@ -261,6 +266,9 @@ class Config:
                 dataset_params["slp_files"] = label_files
             if vid_files is not None:
                 dataset_params["video_files"] = vid_files
+
+            dataset_params["data_dirs"] = self.data_dirs
+
             return SleapDataset(**dataset_params)
 
         elif "tracks" in dataset_params or "source" in dataset_params:

--- a/dreem/models/gtr_runner.py
+++ b/dreem/models/gtr_runner.py
@@ -247,7 +247,7 @@ class GTRRunner(LightningModule):
                 "scheduler": scheduler,
                 "monitor": "val_loss",
                 "interval": "epoch",
-                "frequency": 10,
+                "frequency": 1,
             },
         }
 

--- a/dreem/models/model_utils.py
+++ b/dreem/models/model_utils.py
@@ -165,8 +165,12 @@ def init_scheduler(
             milestones = scheduler_params.get("milestones", None)
             for ix, s in enumerate(scheduler):
                 params = scheduler_params[str(ix)]
-                schedulers.append(getattr(torch.optim.lr_scheduler, s)(optimizer, **params))
-            scheduler_class = torch.optim.lr_scheduler.SequentialLR(optimizer, schedulers, milestones)
+                schedulers.append(
+                    getattr(torch.optim.lr_scheduler, s)(optimizer, **params)
+                )
+            scheduler_class = torch.optim.lr_scheduler.SequentialLR(
+                optimizer, schedulers, milestones
+            )
             return scheduler_class
 
         else:

--- a/dreem/training/configs/base.yaml
+++ b/dreem/training/configs/base.yaml
@@ -45,6 +45,18 @@ scheduler:
   threshold: 1e-4
   threshold_mode: "rel"
 
+  # scheduler: # providing a list of schedulers will apply each scheduler sequentially
+  # name: ["LinearLR", "LinearLR"]
+  # "0": 
+  #   start_factor: 0.1
+  #   end_factor: 1
+  #   total_iters: 3
+  # "1":
+  #   start_factor: 1
+  #   end_factor: 0.1
+  #   total_iters: 30
+  # milestones: [10]
+
 tracker:
   window_size: 8
   use_vis_feats: true

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -163,15 +163,6 @@ def test_sleap_dataset(two_flies):
 
     assert len(train_ds) == ds_length
 
-    train_ds = SleapDataset(
-        slp_files=[two_flies[0]],
-        video_files=[two_flies[1]],
-        crop_size=128,
-        chunk=True,
-        clip_length=clip_length,
-        n_chunks=ds_length + 10000,
-    )
-
     with pytest.raises(Exception):
         train_ds = SleapDataset(
             slp_files=[two_flies[0]],

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -163,6 +163,57 @@ def test_sleap_dataset(two_flies):
 
     assert len(train_ds) == ds_length
 
+    train_ds = SleapDataset(
+        slp_files=[two_flies[0]],
+        video_files=[two_flies[1]],
+        crop_size=128,
+        chunk=True,
+        clip_length=clip_length,
+        n_chunks=ds_length + 10000,
+    )
+
+    with pytest.raises(Exception):
+        train_ds = SleapDataset(
+            slp_files=[two_flies[0]],
+            video_files=[two_flies[1]],
+            data_dirs="./data/sleap",
+            crop_size=[128, 128],
+            chunk=True,
+            clip_length=clip_length,
+            n_chunks=ds_length + 10000,
+        )
+
+    with pytest.raises(Exception):
+        train_ds = SleapDataset(
+            slp_files=[two_flies[0]],
+            video_files=[two_flies[1]],
+            data_dirs=["./data/sleap", "./data/microscopy"],
+            crop_size=[128],
+            chunk=True,
+            clip_length=clip_length,
+            n_chunks=ds_length + 10000,
+        )
+
+    train_ds = SleapDataset(
+        slp_files=[two_flies[0]],
+        video_files=[two_flies[1]],
+        data_dirs=["./data/sleap"],
+        crop_size=128,
+        chunk=True,
+        clip_length=clip_length,
+        n_chunks=ds_length + 10000,
+    )
+
+    train_ds = SleapDataset(
+        slp_files=[two_flies[0]],
+        video_files=[two_flies[1]],
+        data_dirs=["./data/sleap", "./data/microscopy"],
+        crop_size=128,
+        chunk=True,
+        clip_length=clip_length,
+        n_chunks=ds_length + 10000,
+    )
+
 
 def test_icy_dataset(ten_icy_particles):
     """Test icy dataset logic.


### PR DESCRIPTION
- Support multiple crop sizes. see https://github.com/talmolab/dreem/issues/98 for more details

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced flexibility in dataset handling by allowing `crop_size` to accept either an integer or a list of integers.
	- Introduced a new parameter `data_dirs` in the `SleapDataset` for improved data directory management.
	- Added support for multiple learning rate schedulers in the initialization process.
	- Commented-out section in configuration file for potential future enhancements in learning rate scheduling.

- **Bug Fixes**
	- Improved error handling for invalid configurations in the `SleapDataset`, ensuring exceptions are raised for incompatible `data_dirs` and `crop_size`.
	- Streamlined logging of metrics and enhanced error handling for the pod index input.

- **Tests**
	- Expanded test coverage for the `SleapDataset`, validating various configurations and ensuring correct error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->