### PR TITLE
Log train split files

### DIFF
--- a/dreem/io/config.py
+++ b/dreem/io/config.py
@@ -226,7 +226,6 @@ class Config:
         mode: str,
         label_files: list[str] | None = None,
         vid_files: list[str | list[str]] = None,
-        callback: callable | None = None
     ) -> "SleapDataset" | "MicroscopyDataset" | "CellTrackingDataset":
         """Getter for datasets.
 

--- a/dreem/io/config.py
+++ b/dreem/io/config.py
@@ -42,6 +42,8 @@ class Config:
 
         OmegaConf.set_struct(self.cfg, False)
 
+        self._vid_files = {}
+
     def __repr__(self):
         """Object representation of config class."""
         return f"Config({self.cfg})"
@@ -224,6 +226,7 @@ class Config:
         mode: str,
         label_files: list[str] | None = None,
         vid_files: list[str | list[str]] = None,
+        callback: callable | None = None
     ) -> "SleapDataset" | "MicroscopyDataset" | "CellTrackingDataset":
         """Getter for datasets.
 
@@ -276,6 +279,8 @@ class Config:
                 ):
                     dataset_params["normalize_image"] = False
 
+            self.data_paths = (mode, vid_files)
+
             return SleapDataset(**dataset_params)
 
         elif "tracks" in dataset_params or "source" in dataset_params:
@@ -297,6 +302,22 @@ class Config:
                 "Could not resolve dataset type from Config! Please include \
                 either `slp_files` or `tracks`/`source`"
             )
+
+    @property
+    def data_paths(self):
+        """Get data paths.
+        """
+        return self._vid_files
+    
+    @data_paths.setter
+    def data_paths(self, paths: tuple[str, list[str]]):
+        """Set data paths.
+
+        Args:
+            paths: A tuple containing (mode, vid_files)
+        """
+        mode, vid_files = paths
+        self._vid_files[mode] = vid_files
 
     def get_dataloader(
         self,

--- a/dreem/io/config.py
+++ b/dreem/io/config.py
@@ -304,10 +304,9 @@ class Config:
 
     @property
     def data_paths(self):
-        """Get data paths.
-        """
+        """Get data paths."""
         return self._vid_files
-    
+
     @data_paths.setter
     def data_paths(self, paths: tuple[str, list[str]]):
         """Set data paths.

--- a/dreem/training/train.py
+++ b/dreem/training/train.py
@@ -78,6 +78,11 @@ def run(cfg: DictConfig):
 
     run_logger = train_cfg.get_logger()
 
+    if run_logger is not None and isinstance(run_logger, pl.loggers.wandb.WandbLogger):
+        data_paths = train_cfg.data_paths
+        flattened_paths = [[item] for sublist in data_paths.values() for item in sublist]
+        run_logger.log_text("training_files", columns=["data_paths"], data=flattened_paths)
+
     callbacks = []
     _ = callbacks.extend(train_cfg.get_checkpointing())
     _ = callbacks.append(pl.callbacks.LearningRateMonitor())

--- a/dreem/training/train.py
+++ b/dreem/training/train.py
@@ -80,8 +80,12 @@ def run(cfg: DictConfig):
 
     if run_logger is not None and isinstance(run_logger, pl.loggers.wandb.WandbLogger):
         data_paths = train_cfg.data_paths
-        flattened_paths = [[item] for sublist in data_paths.values() for item in sublist]
-        run_logger.log_text("training_files", columns=["data_paths"], data=flattened_paths)
+        flattened_paths = [
+            [item] for sublist in data_paths.values() for item in sublist
+        ]
+        run_logger.log_text(
+            "training_files", columns=["data_paths"], data=flattened_paths
+        )
 
     callbacks = []
     _ = callbacks.extend(train_cfg.get_checkpointing())


### PR DESCRIPTION
Add feature to log exact training data files (currently only for Wandb logger); logs to the table feature in wandb (see screenshot below) and saves a local copy too. Currently, we only log the data directories. However, as we keep adding public data, and we train models with different splits, its important to keep track of exact train/val splits down to the file level. This avoids us from making unnecessary copies of the data just to keep track of it


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a mechanism to manage video file paths in the configuration settings.
	- Enhanced logging functionality for training file paths when using WandbLogger.

- **Bug Fixes**
	- Improved internal state management for video file paths in the configuration class.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->