### PR TITLE
Fix empty batch

### DIFF
--- a/dreem/datasets/base_dataset.py
+++ b/dreem/datasets/base_dataset.py
@@ -110,6 +110,17 @@ class BaseDataset(Dataset):
 
                 self.label_idx = [self.label_idx[i] for i in sample_idx]
 
+            # check for batch with only a single element that correpsonds to the last frame of the video
+            remove_idx = None
+            for i, frame_chunk in enumerate(self.chunked_frame_idx):
+                if len(frame_chunk) == 1 and frame_chunk[0] % self.clip_length == 0:
+                    print("Warning: Single frame batch; removing to avoid empty batch possibility with failed frame loading")
+                    remove_idx = i
+                    break
+            if remove_idx is not None:
+                self.chunked_frame_idx.pop(remove_idx)
+                self.label_idx.pop(remove_idx)
+
         else:
             self.chunked_frame_idx = self.frame_idx
             self.label_idx = [i for i in range(len(self.labels))]
@@ -131,6 +142,7 @@ class BaseDataset(Dataset):
         Returns:
             The batch
         """
+
         return batch
 
     def __getitem__(self, idx: int) -> list[Frame]:

--- a/dreem/datasets/base_dataset.py
+++ b/dreem/datasets/base_dataset.py
@@ -114,7 +114,9 @@ class BaseDataset(Dataset):
             remove_idx = None
             for i, frame_chunk in enumerate(self.chunked_frame_idx):
                 if len(frame_chunk) == 1 and frame_chunk[0] % self.clip_length == 0:
-                    print("Warning: Single frame batch; removing to avoid empty batch possibility with failed frame loading")
+                    print(
+                        "Warning: Single frame batch; removing to avoid empty batch possibility with failed frame loading"
+                    )
                     remove_idx = i
                     break
             if remove_idx is not None:

--- a/dreem/inference/post_processing.py
+++ b/dreem/inference/post_processing.py
@@ -160,7 +160,8 @@ def filter_max_center_dist(
         valid = dist.squeeze() < max_center_dist  # n_k x n_nonk
         # handle case where id_inds and valid is a single value
         # handle this better
-        if valid.ndim == 0: valid = valid.unsqueeze(0)
+        if valid.ndim == 0:
+            valid = valid.unsqueeze(0)
         if valid.ndim == 1:
             if id_inds.shape[0] == 1:
                 valid_mult = valid.float().unsqueeze(-1)


### PR DESCRIPTION
- Currently, if there is a batch with a single frame that also happens to be the last frame of a video, the imageio reader often fails at the last frame (known issue), and this leads to an empty batch which causes the Lightning training loop to fail
- We cannot skip this batch and increment the batch id in the SleapDataset as this conflicts with the Lightning Sampler/Distributed Sampler which is required for multi-GPU training. We also don't have sampler id info in Dataset. One option is to return None which leads to an easier to read error, and the user can fix the data. There is no built-in handling in PyTorch or Lightning of empty batches/None from the data loader currently. 
- In this PR, a temporary workaround is introduced that removes the chunk from the SleapDataset state when it is initialized. This means that batch is never called, which avoids the problem altogether

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of single-frame batches in dataset processing to prevent potential loading issues.
	- Enhanced tensor dimension handling in post-processing filtering function.

- **Style**
	- Improved code formatting and readability in post-processing function.
	- Added blank line for better readability in the `no_batching_fn` method.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->