### PR TITLE
Fix missing instance frame

### DIFF
--- a/dreem/datasets/sleap_dataset.py
+++ b/dreem/datasets/sleap_dataset.py
@@ -145,7 +145,9 @@ class SleapDataset(BaseDataset):
 
         # note if slp is missing frames, taking last frame idx is safer than len(labels)
         # as there will be fewer labeledframes than actual frames
-        self.frame_idx = [torch.arange(labels[-1].frame_idx + 1) for labels in self.labels]
+        self.frame_idx = [
+            torch.arange(labels[-1].frame_idx + 1) for labels in self.labels
+        ]
         self.skipped_frame_ct = [0 for labels in self.labels]
         # self.frame_idx = [torch.arange(len(labels)) for labels in self.labels]
         # Method in BaseDataset. Creates label_idx and chunked_frame_idx to be
@@ -213,7 +215,6 @@ class SleapDataset(BaseDataset):
                 )
                 self.skipped_frame_ct[label_idx] += 1
                 continue
-
 
             try:
                 img = vid_reader.get_data(int(lf.frame_idx))

--- a/dreem/datasets/sleap_dataset.py
+++ b/dreem/datasets/sleap_dataset.py
@@ -143,7 +143,11 @@ class SleapDataset(BaseDataset):
         # for label in self.labels:
         # label.remove_empty_instances(keep_empty_frames=False)
 
-        self.frame_idx = [torch.arange(len(labels)) for labels in self.labels]
+        # note if slp is missing frames, taking last frame idx is safer than len(labels)
+        # as there will be fewer labeledframes than actual frames
+        self.frame_idx = [torch.arange(labels[-1].frame_idx + 1) for labels in self.labels]
+        self.skipped_frame_ct = [0 for labels in self.labels]
+        # self.frame_idx = [torch.arange(len(labels)) for labels in self.labels]
         # Method in BaseDataset. Creates label_idx and chunked_frame_idx to be
         # used in call to get_instances()
         self.create_chunks()
@@ -168,7 +172,6 @@ class SleapDataset(BaseDataset):
 
         """
         video = self.labels[label_idx]
-
         video_name = self.video_files[label_idx]
 
         # get the correct crop size based on the video
@@ -201,7 +204,16 @@ class SleapDataset(BaseDataset):
 
             frame_ind = int(frame_ind)
 
-            lf = video[frame_ind]
+            # if slp is missing instances in some frames, frame_ind will be smaller than lf.frame_idx
+            lf = video[frame_ind - self.skipped_frame_ct[label_idx]]
+            if frame_ind < lf.frame_idx:
+                logger.warning(
+                    f"Frame index {frame_ind} is trying to access frame {lf.frame_idx} of the slp file {video_name}. "
+                    f"This likely means there are no labelled instances in this frame. Skipping frame."
+                )
+                self.skipped_frame_ct[label_idx] += 1
+                continue
+
 
             try:
                 img = vid_reader.get_data(int(lf.frame_idx))


### PR DESCRIPTION
We are currently not checking for missing frames in the input .slp file to ensure alignment between expected number of frames from the video, and LabeledFrame count. We assume that frame_ind from chunked frames matches lf.frame_idx but it does not. The issue is that we index the labels based on enumerating the length of the slp Labels() object. We need to ensure the frame_ind in SleapDataset matches lf.frame_idx

This line highlights the source of the issue (len(labels)): self.frame_idx = [torch.arange(len(labels)) for labels in self.labels] 
Fix: First, enumerate frame_idx using the lf.frame_idx value of the last frame in the slp file. This ensures the indexing stays correct till the end of the video. Then, since there will now be missing frame ids in slp, check that the chunk’s frame index is equal to lf.frame_idx, and if not, skip the frame. But, we need to keep track of how many frames we’ve skipped, otherwise even if frame_ind = lf.frame_idx, trying to index labels[frame_ind] will overshoot the correct frame! Also, since frames can be skipped across batches, the skip counter must be part of the SleapDataset state so that it persists throughout the entire video! (Rather than being reset every batch)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced dataset reliability by refining the frame loading process to better accommodate missing frames.
  - Improved error feedback during video frame processing, resulting in a more stable and predictable experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->