### PR TITLE
patch checkpointing so the last checkpoint saves with the tag `final` …

### DIFF
--- a/dreem/io/config.py
+++ b/dreem/io/config.py
@@ -492,7 +492,7 @@ class Config:
                 filename=f"{{epoch}}-{{{metric}}}",
                 **checkpoint_params,
             )
-            checkpointer.CHECKPOINT_NAME_LAST = f"{{epoch}}-best-{{{metric}}}"
+            checkpointer.CHECKPOINT_NAME_LAST = f"{{epoch}}-final-{{{metric}}}"
             checkpointers.append(checkpointer)
         return checkpointers
 


### PR DESCRIPTION
…instead of `best` which is a misrepresentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- The naming for saved model checkpoints was updated: end-of-training checkpoints now use a “final” label instead of a “best” designation, making it clearer which model state represents the final training outcome.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->