### PR TITLE
Update eval pipeline

### DIFF
--- a/dreem/inference/eval.py
+++ b/dreem/inference/eval.py
@@ -47,11 +47,11 @@ def run(cfg: DictConfig) -> dict[int, sio.Labels]:
     model.tracker = Tracker(**model.tracker_cfg)
     logger.info(f"Using the following tracker:")
     print(model.tracker)
-    model.metrics["test"] = eval_cfg.cfg.runner.metrics.test
+    model.metrics["test"] = eval_cfg.cfg.metrics.test
     model.persistent_tracking["test"] = True
     logger.info(f"Computing the following metrics:")
     logger.info(model.metrics["test"])
-    model.test_results["save_path"] = eval_cfg.cfg.runner.save_path
+    model.test_results["save_path"] = eval_cfg.cfg.save_path
     logger.info(f"Saving results to {model.test_results['save_path']}")
 
     labels_files, vid_files = eval_cfg.get_data_paths(eval_cfg.cfg.dataset.test_dataset)

--- a/dreem/inference/eval.py
+++ b/dreem/inference/eval.py
@@ -52,7 +52,7 @@ def run(cfg: DictConfig) -> dict[int, sio.Labels]:
     logger.info(f"Computing the following metrics:")
     logger.info(model.metrics["test"])
     model.test_results["save_path"] = eval_cfg.cfg.save_path
-    logger.info(f"Saving results to {model.test_results['save_path']}")
+    logger.info(f"Saving tracking results and metrics to {model.test_results['save_path']}")
 
     labels_files, vid_files = eval_cfg.get_data_paths(eval_cfg.cfg.dataset.test_dataset)
     trainer = eval_cfg.get_trainer()

--- a/dreem/inference/eval.py
+++ b/dreem/inference/eval.py
@@ -52,7 +52,9 @@ def run(cfg: DictConfig) -> dict[int, sio.Labels]:
     logger.info(f"Computing the following metrics:")
     logger.info(model.metrics["test"])
     model.test_results["save_path"] = eval_cfg.cfg.save_path
-    logger.info(f"Saving tracking results and metrics to {model.test_results['save_path']}")
+    logger.info(
+        f"Saving tracking results and metrics to {model.test_results['save_path']}"
+    )
 
     labels_files, vid_files = eval_cfg.get_data_paths(eval_cfg.cfg.dataset.test_dataset)
     trainer = eval_cfg.get_trainer()

--- a/dreem/inference/eval.py
+++ b/dreem/inference/eval.py
@@ -48,9 +48,7 @@ def run(cfg: DictConfig) -> dict[int, sio.Labels]:
     logger.info(f"Using the following tracker:")
     print(model.tracker)
     model.metrics["test"] = eval_cfg.cfg.runner.metrics.test
-    model.persistent_tracking["test"] = eval_cfg.cfg.tracker.get(
-        "persistent_tracking", False
-    )
+    model.persistent_tracking["test"] = True
     logger.info(f"Computing the following metrics:")
     logger.info(model.metrics["test"])
     model.test_results["save_path"] = eval_cfg.cfg.runner.save_path

--- a/dreem/inference/metrics.py
+++ b/dreem/inference/metrics.py
@@ -284,7 +284,7 @@ def compute_motmetrics(df):
     """
     summary_dreem = {}
     acc_dreem = mm.MOTAccumulator(auto_id=True)
-
+    frame_switch_map = {}
     for frame, framedf in df.groupby('frame_id'):
         gt_ids = framedf['gt_track_id'].values
         pred_tracks = framedf['pred_track_id'].values
@@ -304,8 +304,14 @@ def compute_motmetrics(df):
     # get pymotmetrics summary    
     mh = mm.metrics.create()
     summary_dreem = mh.compute(acc_dreem, name="acc").transpose()
+    
+    for row in acc_dreem.mot_events.iterrows():
+        if row['event'] == 'SWITCH':
+            frame_switch_map[int(row['frame_id'])] = True
+        else:
+            frame_switch_map[int(row['frame_id'])] = False
 
-    return summary_dreem, acc_dreem.mot_events
+    return summary_dreem, acc_dreem.mot_events, frame_switch_map
 
 
 def compute_global_tracking_accuracy(df):

--- a/dreem/inference/metrics.py
+++ b/dreem/inference/metrics.py
@@ -11,8 +11,7 @@ logger = logging.getLogger("dreem.inference")
 
 
 def get_matches(frames: list["dreem.io.Frame"]) -> tuple[dict, list, int]:
-    """Get comparison between predicted and gt trajectory labels.
-    Deprecated.
+    """Get comparison between predicted and gt trajectory labels. Deprecated.
 
     Args:
         frames: a list of Frames containing the video_id, frame_id,
@@ -46,8 +45,7 @@ def get_matches(frames: list["dreem.io.Frame"]) -> tuple[dict, list, int]:
 
 
 def get_switches(matches: dict, indices: list) -> dict:
-    """Get misassigned predicted trajectory labels.
-    Deprecated.
+    """Get misassigned predicted trajectory labels. Deprecated.
 
     Args:
         matches: a dict containing the gt and predicted labels
@@ -89,8 +87,7 @@ def get_switches(matches: dict, indices: list) -> dict:
 
 
 def get_switch_count(switches: dict) -> int:
-    """Get the number of mislabeled predicted trajectories.
-    Deprecated.
+    """Get the number of mislabeled predicted trajectories. Deprecated.
 
     Args:
         switches: a dict of dicts containing the mislabeled trajectories
@@ -115,7 +112,7 @@ def evaluate(preds, metrics):
         A dict of metrics with key being the metric, and value being the metric value computed.
     """
     metric_fcn_map = {
-        "num_switches": compute_motmetrics,
+        "motmetrics": compute_motmetrics,
         "global_tracking_accuracy": compute_global_tracking_accuracy,
     }
     list_frame_info = []

--- a/dreem/inference/metrics.py
+++ b/dreem/inference/metrics.py
@@ -9,12 +9,10 @@ from typing import Iterable
 
 logger = logging.getLogger("dreem.inference")
 
-# from dreem.inference.post_processing import _pairwise_iou
-# from dreem.inference.boxes import Boxes
-
 
 def get_matches(frames: list["dreem.io.Frame"]) -> tuple[dict, list, int]:
     """Get comparison between predicted and gt trajectory labels.
+    Deprecated.
 
     Args:
         frames: a list of Frames containing the video_id, frame_id,
@@ -49,6 +47,7 @@ def get_matches(frames: list["dreem.io.Frame"]) -> tuple[dict, list, int]:
 
 def get_switches(matches: dict, indices: list) -> dict:
     """Get misassigned predicted trajectory labels.
+    Deprecated.
 
     Args:
         matches: a dict containing the gt and predicted labels
@@ -91,6 +90,7 @@ def get_switches(matches: dict, indices: list) -> dict:
 
 def get_switch_count(switches: dict) -> int:
     """Get the number of mislabeled predicted trajectories.
+    Deprecated.
 
     Args:
         switches: a dict of dicts containing the mislabeled trajectories
@@ -102,136 +102,6 @@ def get_switch_count(switches: dict) -> int:
     only_switches = {k: v for k, v in switches.items() if v != {}}
     sw_cnt = sum([len(i) for i in list(only_switches.values())])
     return sw_cnt
-
-
-def to_track_eval(frames: list["dreem.io.Frame"]) -> dict:
-    """Reformats frames the output from `sliding_inference` to be used by `TrackEval`.
-    Deprecated.
-
-    Args:
-        frames: A list of Frames. `See dreem.io.data_structures for more info`.
-
-    Returns:
-        data: A dictionary. Example provided below.
-
-    # --------------------------- An example of data --------------------------- #
-
-    *: number of ids for gt at every frame of the video
-    ^: number of ids for tracker at every frame of the video
-    L: length of video
-
-    data = {
-        "num_gt_ids": total number of unique gt ids,
-        "num_tracker_dets": total number of detections by your detection algorithm,
-        "num_gt_dets": total number of gt detections,
-        "gt_ids": (L, *),  # Ragged np.array
-        "tracker_ids": (L, ^),  # Ragged np.array
-        "similarity_scores": (L, *, ^),  # Ragged np.array
-        "num_timesteps": L,
-    }
-    """
-    unique_gt_ids = []
-    num_tracker_dets = 0
-    num_gt_dets = 0
-    gt_ids = []
-    track_ids = []
-    similarity_scores = []
-
-    data = {}
-    cos_sim = torch.nn.CosineSimilarity()
-
-    for fidx, frame in enumerate(frames):
-        gt_track_ids = frame.get_gt_track_ids().cpu().numpy().tolist()
-        pred_track_ids = frame.get_pred_track_ids().cpu().numpy().tolist()
-        # boxes = Boxes(frame.get_bboxes().cpu())
-
-        gt_ids.append(np.array(gt_track_ids))
-        track_ids.append(np.array(pred_track_ids))
-
-        num_tracker_dets += len(pred_track_ids)
-        num_gt_dets += len(gt_track_ids)
-
-        if not set(gt_track_ids).issubset(set(unique_gt_ids)):
-            unique_gt_ids.extend(list(set(gt_track_ids).difference(set(unique_gt_ids))))
-
-        # eval_matrix = _pairwise_iou(boxes, boxes)
-        eval_matrix = np.full((len(gt_track_ids), len(pred_track_ids)), np.nan)
-
-        for i, feature_i in enumerate(frame.get_features()):
-            for j, feature_j in enumerate(frame.get_features()):
-                eval_matrix[i][j] = cos_sim(
-                    feature_i.unsqueeze(0), feature_j.unsqueeze(0)
-                )
-
-        # eval_matrix
-        #                      pred_track_ids
-        #                            0        1
-        #  gt_track_ids    1        ...      ...
-        #                  0        ...      ...
-        #
-        # Since the order of both gt_track_ids and pred_track_ids matter (maps from pred to gt),
-        # we know the diagonal is the important part. E.g. gt_track_ids=1 maps to pred_track_ids=0
-        # and gt_track_ids=0 maps to pred_track_ids=1 because they are ordered in that way.
-
-        # Based on assumption that eval_matrix is always a square matrix.
-        # This is true because we are using ground-truth detections.
-        #
-        # - The number of predicted tracks for a frame will always be the same number
-        # of ground truth tracks for a frame.
-        # - The number of predicted and ground truth detections will always be the same
-        # for any frame.
-        # - Because we map detections to features one-to-one, there will always be the same
-        # number of features for both predicted and ground truth for any frame.
-
-        # Mask upper and lower triangles of the square matrix (set to 0).
-        eval_matrix = np.triu(np.tril(eval_matrix))
-
-        # Replace the 0s with np.nans.
-        i, j = np.where(eval_matrix == 0)
-        eval_matrix[i, j] = np.nan
-
-        similarity_scores.append(eval_matrix)
-
-    data["num_gt_ids"] = len(unique_gt_ids)
-    data["num_tracker_dets"] = num_tracker_dets
-    data["num_gt_dets"] = num_gt_dets
-    data["gt_ids"] = gt_ids
-    data["tracker_ids"] = track_ids
-    data["similarity_scores"] = similarity_scores
-    data["num_timesteps"] = len(frames)
-
-    return data
-
-
-def get_track_evals(data: dict, metrics: dict) -> dict:
-    """Run track_eval and get mot metrics.
-    Deprecated.
-    Args:
-        data: A dictionary. Example provided below.
-        metrics: mot metrics to be computed
-    Returns:
-        A dictionary with key being the metric, and value being the metric value computed.
-    # --------------------------- An example of data --------------------------- #
-
-    *: number of ids for gt at every frame of the video
-    ^: number of ids for tracker at every frame of the video
-    L: length of video
-
-    data = {
-        "num_gt_ids": total number of unique gt ids,
-        "num_tracker_dets": total number of detections by your detection algorithm,
-        "num_gt_dets": total number of gt detections,
-        "gt_ids": (L, *),  # Ragged np.array
-        "tracker_ids": (L, ^),  # Ragged np.array
-        "similarity_scores": (L, *, ^),  # Ragged np.array
-        "num_timsteps": L,
-    }
-    """
-    results = {}
-    for metric_name, metric in metrics.items():
-        result = metric.eval_sequence(data)
-        results.update(result)
-    return results
 
 
 def evaluate(preds, metrics):

--- a/dreem/models/gtr_runner.py
+++ b/dreem/models/gtr_runner.py
@@ -78,7 +78,7 @@ class GTRRunner(LightningModule):
             if persistent_tracking is not None
             else self.DEFAULT_TRACKING
         )
-        self.test_results = {"metrics": [], "preds": [], "save_path": test_save_path}
+        self.test_results = {"metrics": {}, "preds": [], "save_path": test_save_path}
 
     def forward(
         self,
@@ -271,7 +271,14 @@ class GTRRunner(LightningModule):
             test_results: dict containing predictions and metrics to be filled out in metrics.evaluate
             metrics: list of metrics to compute
         """
-        metrics.evaluate(self.test_results, self.metrics["test"])
+        metrics = self.metrics["test"] # list of metrics to compute, or "all"
+        if metrics == "all":
+            metrics = ["num_switches", "global_tracking_accuuracy"]
+        test_metrics = metrics.evaluate(self.test_results, metrics)
+        # test_metrics is a dict with key being the metric, and value being the metric value computed.
+        self.test_results["metrics"] = test_metrics
+        # save the results to an hdf5 file
+
 
     # def on_test_epoch_end(self):
     #     """Execute hook for test end.

--- a/dreem/models/gtr_runner.py
+++ b/dreem/models/gtr_runner.py
@@ -380,47 +380,4 @@ class GTRRunner(LightningModule):
         pred_slp = sio.Labels(pred_slp)
 
         pred_slp.save(outpath)
-
-    # def on_test_epoch_end(self):
-    #     """Execute hook for test end.
-
-    #     Currently, we save results to an h5py file. and clear the predictions
-    #     """
-    #     fname = self.test_results["save_path"]
-    #     test_results = {
-    #         key: val for key, val in self.test_results.items() if key != "save_path"
-    #     }
-    #     metrics_dict = [
-    #         {
-    #             key: (
-    #                 val.detach().cpu().numpy() if isinstance(val, torch.Tensor) else val
-    #             )
-    #             for key, val in metrics.items()
-    #         }
-    #         for metrics in test_results["metrics"]
-    #     ]
-    #     results_df = pd.DataFrame(metrics_dict)
-    #     preds = test_results["preds"]
-
-    #     with h5py.File(fname, "a") as results_file:
-    #         for key in results_df.columns:
-    #             avg_result = results_df[key].mean()
-    #             results_file.attrs.create(key, avg_result)
-    #         for i, (metrics, frames) in enumerate(zip(metrics_dict, preds)):
-    #             vid_name = frames[0].vid_name.split("/")[-1].split(".")[0]
-    #             vid_group = results_file.require_group(vid_name)
-    #             clip_group = vid_group.require_group(f"clip_{i}")
-    #             for key, val in metrics.items():
-    #                 clip_group.attrs.create(key, val)
-    #             for frame in frames:
-    #                 if metrics.get("num_switches", 0) > 0:
-    #                     _ = frame.to_h5(
-    #                         clip_group,
-    #                         frame.get_gt_track_ids().cpu().numpy(),
-    #                         save={"crop": True, "features": True, "embeddings": True},
-    #                     )
-    #                 else:
-    #                     _ = frame.to_h5(
-    #                         clip_group, frame.get_gt_track_ids().cpu().numpy()
-    #                     )
-    #     self.test_results = {"metrics": [], "preds": [], "save_path": fname}
+        

--- a/dreem/models/gtr_runner.py
+++ b/dreem/models/gtr_runner.py
@@ -18,6 +18,7 @@ import sleap_io as sio
 
 logger = logging.getLogger("dreem.models")
 
+
 class GTRRunner(LightningModule):
     """A lightning wrapper around GTR model.
 
@@ -274,14 +275,18 @@ class GTRRunner(LightningModule):
             metrics: list of metrics to compute
         """
         # input validation
-        metrics_to_compute = self.metrics["test"] # list of metrics to compute, or "all"
+        metrics_to_compute = self.metrics[
+            "test"
+        ]  # list of metrics to compute, or "all"
         if metrics_to_compute == "all":
             metrics_to_compute = ["num_switches", "global_tracking_accuracy"]
         if isinstance(metrics_to_compute, str):
             metrics_to_compute = [metrics_to_compute]
         for metric in metrics_to_compute:
             if metric not in ["num_switches", "global_tracking_accuracy"]:
-                raise ValueError(f"Metric {metric} not supported. Please select from 'num_switches' or 'global_tracking_accuracy'")
+                raise ValueError(
+                    f"Metric {metric} not supported. Please select from 'num_switches' or 'global_tracking_accuracy'"
+                )
 
         preds = self.test_results["preds"]
 
@@ -289,7 +294,7 @@ class GTRRunner(LightningModule):
         results = metrics.evaluate(preds, metrics_to_compute)
 
         # save metrics and frame metadata to hdf5
-        
+
         # Get the video name from the first frame
         vid_name = Path(preds[0].vid_name).stem
         # save the results to an hdf5 file
@@ -302,8 +307,10 @@ class GTRRunner(LightningModule):
         original_fname = fname
         while os.path.exists(fname):
             suffix_counter += 1
-            fname = original_fname.replace(".dreem_metrics.h5", f"_{suffix_counter}.dreem_metrics.h5")
-        
+            fname = original_fname.replace(
+                ".dreem_metrics.h5", f"_{suffix_counter}.dreem_metrics.h5"
+            )
+
         if suffix_counter > 0:
             print(f"File already exists. Saving to {fname} instead")
 
@@ -328,14 +335,20 @@ class GTRRunner(LightningModule):
                             _ = frame.to_h5(
                                 vid_group,
                                 frame.get_gt_track_ids().cpu().numpy(),
-                                save={"crop": True, "features": True, "embeddings": True},
+                                save={
+                                    "crop": True,
+                                    "features": True,
+                                    "embeddings": True,
+                                },
                             )
                         else:
                             _ = frame.to_h5(
                                 vid_group, frame.get_gt_track_ids().cpu().numpy()
                             )
                     # save motevents log to csv
-                    motevents_path = os.path.join(self.test_results["save_path"], f"{vid_name}.motevents.csv")
+                    motevents_path = os.path.join(
+                        self.test_results["save_path"], f"{vid_name}.motevents.csv"
+                    )
                     print(f"Saving motevents log to {motevents_path}")
                     mot_events.to_csv(motevents_path, index=False)
 
@@ -345,11 +358,12 @@ class GTRRunner(LightningModule):
                     # save as a key value pair with gt track id: gta
                     for gt_track_id, gta in gta_by_gt_track.items():
                         gta_group.attrs[f"track_{gt_track_id}"] = gta
-        
+
         # save the tracking results to a slp file
         pred_slp = []
         outpath = os.path.join(
-            self.test_results["save_path"], f"{vid_name}.dreem_inference.{datetime.now().strftime('%m-%d-%Y-%H-%M-%S')}.slp"
+            self.test_results["save_path"],
+            f"{vid_name}.dreem_inference.{datetime.now().strftime('%m-%d-%Y-%H-%M-%S')}.slp",
         )
         print(f"Saving inference results to {outpath}")
         # save the tracking results to a slp file
@@ -364,9 +378,8 @@ class GTRRunner(LightningModule):
             lf, tracks = frame.to_slp(tracks, video=video)
             pred_slp.append(lf)
         pred_slp = sio.Labels(pred_slp)
-        
-        pred_slp.save(outpath)
 
+        pred_slp.save(outpath)
 
     # def on_test_epoch_end(self):
     #     """Execute hook for test end.

--- a/scripts/extract_metrics.ipynb
+++ b/scripts/extract_metrics.ipynb
@@ -1,0 +1,100 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import h5py\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hdf5_path = \"/root/vast/mustafa/dreem-experiments/run/dev/eval-pipeline/three_flies_2.dreem_metrics.h5\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dict_vid_motmetrics = {}\n",
+    "dict_vid_gta = {}\n",
+    "dict_vid_switch_frame_crops = {}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Extracting metrics and crops for video:  three_flies\n"
+     ]
+    }
+   ],
+   "source": [
+    "with h5py.File(hdf5_path, \"r\") as results_file:\n",
+    "    # Iterate through all video groups\n",
+    "    for vid_name in results_file.keys():\n",
+    "        print(\"Extracting metrics and crops for video: \", vid_name)\n",
+    "        vid_group = results_file[vid_name]\n",
+    "        # Load MOT summary\n",
+    "        if \"mot_summary\" in vid_group:\n",
+    "            mot_summary_keys = list(vid_group[\"mot_summary\"].attrs)\n",
+    "            mot_summary_values = [vid_group[\"mot_summary\"].attrs[key] for key in mot_summary_keys]\n",
+    "            df_motmetrics = pd.DataFrame(list(zip(mot_summary_keys, mot_summary_values)), columns=[\"metric\", \"value\"])\n",
+    "            dict_vid_motmetrics[vid_name] = df_motmetrics\n",
+    "        # Load global tracking accuracy if available\n",
+    "        if \"global_tracking_accuracy\" in vid_group:\n",
+    "            gta_keys = list(vid_group[\"global_tracking_accuracy\"].attrs)\n",
+    "            gta_values = [vid_group[\"global_tracking_accuracy\"].attrs[key] for key in gta_keys]\n",
+    "            df_gta = pd.DataFrame(list(zip(gta_keys, gta_values)), columns=[\"metric\", \"value\"])\n",
+    "            dict_vid_gta[vid_name] = df_gta\n",
+    "        # Find all frames with switches and save the crops\n",
+    "        frame_crop_dict = {}\n",
+    "        for key in vid_group.keys():\n",
+    "            if key.startswith(\"frame_\"):\n",
+    "                frame = vid_group[key]\n",
+    "                frame_id = frame.attrs[\"frame_id\"]\n",
+    "                for key in frame.keys():\n",
+    "                    if key.startswith(\"instance_\"):\n",
+    "                        instance = frame[key]\n",
+    "                        if \"crop\" in instance.keys():\n",
+    "                            frame_crop_dict[frame_id] = instance[\"crop\"][:].squeeze().transpose(1,2,0)\n",
+    "        dict_vid_switch_frame_crops[vid_name] = frame_crop_dict"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "dreem",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/scripts/extract_metrics.ipynb
+++ b/scripts/extract_metrics.ipynb
@@ -74,6 +74,22 @@
     "                            frame_crop_dict[frame_id] = instance[\"crop\"][:].squeeze().transpose(1,2,0)\n",
     "        dict_vid_switch_frame_crops[vid_name] = frame_crop_dict"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# see the motmetrics summary\n",
+    "dict_vid_motmetrics\n",
+    "\n",
+    "# see the global tracking accuracy\n",
+    "dict_vid_gta\n",
+    "\n",
+    "# see the switch frame crops\n",
+    "dict_vid_switch_frame_crops"
+   ]
   }
  ],
  "metadata": {

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -234,36 +234,30 @@ def test_metrics():
     """Test basic GTR Runner."""
     num_frames = 3
     num_detected = 3
-    n_batches = 1
-    batches = []
+    metrics_to_compute = ["num_switches", "global_tracking_accuracy"]
 
-    for i in range(n_batches):
-        frames_pred = []
-        for j in range(num_frames):
-            instances_pred = []
-            for k in range(num_detected):
-                bboxes = torch.tensor(np.random.uniform(size=(num_detected, 4)))
-                bboxes[:, -2:] += 1
-                instances_pred.append(
-                    Instance(gt_track_id=k, pred_track_id=k, bbox=torch.randn((1, 4)))
-                )
-            frames_pred.append(Frame(video_id=0, frame_id=j, instances=instances_pred))
-        batches.append(frames_pred)
+    frames_pred = []
+    for i in range(num_frames):
+        instances_pred = []
+        for k in range(num_detected):
+            bboxes = torch.tensor(np.random.uniform(size=(num_detected, 4)))
+            bboxes[:, -2:] += 1
+            instances_pred.append(
+                Instance(gt_track_id=k, pred_track_id=k, bbox=torch.randn((1, 4)))
+            )
+        frames_pred.append(Frame(video_id=0, frame_id=i, instances=instances_pred))
 
-    for batch in batches:
-        instances_mm = metrics.to_track_eval(batch)
-        clear_mot = metrics.get_pymotmetrics(instances_mm)
+    results = metrics.evaluate(frames_pred, metrics_to_compute)
+    for metric_name, value in results.items():
+        if metric_name == "num_switches":
+            mot_summary = value[0]
+            switch_count = mot_summary.loc["num_switches"].values[0]
+        elif metric_name == "global_tracking_accuracy":
+            gta_by_gt_track = value
+            overall_gta = np.mean(np.array(list(gta_by_gt_track.values())))
 
-        matches, indices, _ = metrics.get_matches(batch)
-
-        switches = metrics.get_switches(matches, indices)
-
-        sw_cnt = metrics.get_switch_count(switches)
-
-        assert sw_cnt == clear_mot["num_switches"] == 0, (
-            sw_cnt,
-            clear_mot["num_switches"],
-        )
+    assert switch_count == 0
+    assert 0 < overall_gta <= 1
 
 
 def get_ckpt(ckpt_path: str):

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -234,7 +234,7 @@ def test_metrics():
     """Test basic GTR Runner."""
     num_frames = 3
     num_detected = 3
-    metrics_to_compute = ["num_switches", "global_tracking_accuracy"]
+    metrics_to_compute = ["motmetrics", "global_tracking_accuracy"]
 
     frames_pred = []
     for i in range(num_frames):
@@ -249,7 +249,7 @@ def test_metrics():
 
     results = metrics.evaluate(frames_pred, metrics_to_compute)
     for metric_name, value in results.items():
-        if metric_name == "num_switches":
+        if metric_name == "motmetrics":
             mot_summary = value[0]
             switch_count = mot_summary.loc["num_switches"].values[0]
         elif metric_name == "global_tracking_accuracy":


### PR DESCRIPTION
This PR overhauls the eval pipeline. It maintains compatibility with dreem-eval

1. Moves metric calculation from end of each test epoch, to end of test run. This greatly simplifies the flow
2. Streamline the computation of metrics using a common data format - gt and preds are combined into a df which is then passed to each metric function
3. Update and simplify mot metrics calculation to improve reliability
4. Saves the mot events log (frame by frame switch/match) to disk along with the metrics and the slp tracking file
5. Introduce global tracking accuracy metric as a default metric to be computed
6. Save the results of the tracking (done before metrics are computed) to an slp file. Previously, eval pipeline only  saved the metrics and frame metadata
7. Maintains previous functionality of saving metrics to hdf5, along with crops and feature vectors for frames in which a switch occurs
8. Adds a notebook in /scripts which helps users extract the metrics and crops from the hdf5 eval output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a Jupyter Notebook for extracting metrics and crops from HDF5 files containing video data.
- **Refactor**
	- Streamlined the configuration and evaluation pipeline for tracking metrics with clearer logging.
	- Revised result saving to improve organization and prevent file conflicts.
- **Bug Fixes**
	- Enhanced error handling for configuration retrieval and improved clarity in logging outputs.
- **Tests**
	- Simplified the testing process for tracking performance to ensure more direct and reliable metric evaluations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->