### PR TITLE
General clean-up and DevOps enhancements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,45 @@
+name: Build
+
+on:
+  release:
+    types:
+      - published
+  # # Modify and uncomment below to manually trigger build:
+  # push:
+  #   branches:
+  #     - main
+
+jobs:
+  pypi:
+    name: PyPI Wheel
+    runs-on: "ubuntu-22.04"
+    steps:
+
+    - name: Checkout repo
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v4
+      with:
+        enable-cache: true
+        cache-dependency-glob: "pyproject.toml"
+
+    - name: Install dependencies
+      run: |
+        uv pip install --system build twine
+
+    - name: Build wheel
+      run: |
+        uv build --no-sources
+        twine check dist/*
+    
+    - name: Upload
+      env:
+        PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+      run: |
+        twine upload -u __token__ -p "$PYPI_TOKEN" dist/* --non-interactive --skip-existing --disable-progress-bar

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,8 @@ jobs:
   pypi:
     name: PyPI Wheel
     runs-on: "ubuntu-22.04"
+    permissions:
+      id-token: write
     steps:
 
     - name: Checkout repo
@@ -38,8 +40,5 @@ jobs:
         uv build --no-sources
         twine check dist/*
     
-    - name: Upload
-      env:
-        PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-      run: |
-        twine upload -u __token__ -p "$PYPI_TOKEN" dist/* --non-interactive --skip-existing --disable-progress-bar
+    - name: Upload to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,14 +31,10 @@ jobs:
         enable-cache: true
         cache-dependency-glob: "pyproject.toml"
 
-    - name: Install dependencies
-      run: |
-        uv pip install --system build twine
-
     - name: Build wheel
       run: |
         uv build --no-sources
-        twine check dist/*
     
     - name: Upload to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      run: |
+        uv publish --trusted-publishing always

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -1,0 +1,46 @@
+# Windows CI - Manual trigger only
+name: CI Windows
+
+on:
+  workflow_dispatch:
+
+defaults:
+  # This is needed for running steps within conda environments.
+  run:
+    shell: bash -l {0}
+
+jobs:
+  # Tests with pytest on Windows
+  tests-windows:
+    name: Tests (Windows, Python 3.12)
+    runs-on: windows-2022
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Setup Micromamba
+        # https://github.com/mamba-org/setup-micromamba
+        # Note: Set channel-priority in .condarc if needed
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-file: environment_cpu.yml
+          cache-environment: true
+          cache-environment-key: environment-${{ hashFiles('environment_cpu.yml') }}-${{ hashFiles('pyproject.toml') }}
+          init-shell: >-
+            bash
+            powershell
+          post-cleanup: all
+
+      - name: Print environment info
+        shell: bash -l {0}
+        run: |
+          which python
+          micromamba info
+          micromamba list
+          pip freeze
+
+      - name: Test with pytest
+        shell: bash -l {0}
+        run: |
+          pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,21 +95,14 @@ jobs:
           micromamba list
           pip freeze
 
-      - name: Test with pytest
-        if: ${{ !(startsWith(matrix.os, 'ubuntu') && matrix.python == 3.12) }}
-        shell: bash -l {0}
-        run: |
-          pytest
-
       - name: Test with pytest (with coverage)
-        if: ${{ startsWith(matrix.os, 'ubuntu') && matrix.python == 3.12 }}
         shell: bash -l {0}
         run: |
           pytest --cov=dreem --cov-report=xml tests/
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v3
-        if: ${{ startsWith(matrix.os, 'ubuntu') && matrix.python == 3.12 }}
+        uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: false
           verbose: true
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-22.04", "windows-2022"]
+        os: ["ubuntu-22.04"]
         python: [3.12]
 
     name: Tests (${{ matrix.os }}, Python ${{ matrix.python }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: 3.12
 
     - name: Install dependencies
       run: |
@@ -65,7 +65,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-22.04", "windows-2022"]
-        python: [3.9]
+        python: [3.12]
 
     name: Tests (${{ matrix.os }}, Python ${{ matrix.python }})
     runs-on: ${{ matrix.os }}
@@ -96,20 +96,20 @@ jobs:
           pip freeze
 
       - name: Test with pytest
-        if: ${{ !(startsWith(matrix.os, 'ubuntu') && matrix.python == 3.9) }}
+        if: ${{ !(startsWith(matrix.os, 'ubuntu') && matrix.python == 3.12) }}
         shell: bash -l {0}
         run: |
           pytest
 
       - name: Test with pytest (with coverage)
-        if: ${{ startsWith(matrix.os, 'ubuntu') && matrix.python == 3.9 }}
+        if: ${{ startsWith(matrix.os, 'ubuntu') && matrix.python == 3.12 }}
         shell: bash -l {0}
         run: |
           pytest --cov=dreem --cov-report=xml tests/
 
       - name: Upload coverage
         uses: codecov/codecov-action@v3
-        if: ${{ startsWith(matrix.os, 'ubuntu') && matrix.python == 3.9 }}
+        if: ${{ startsWith(matrix.os, 'ubuntu') && matrix.python == 3.12 }}
         with:
           fail_ci_if_error: false
           verbose: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,13 +26,13 @@ defaults:
     shell: bash -l {0}
 
 jobs:
-  # Lint with black, docstring check with pydocstyle, static type checking with mypy
+  # Format and lint with ruff
   lint:
     # This job runs:
     #
-    # 1. Linting with black
+    # 1. Format checking with ruff format
     #
-    # 2. Docstring style checking with pydocstyle 
+    # 2. Linting and docstring checking with ruff check
     # Note: This uses Google-style docstring convention
     # Ref: https://google.github.io/styleguide/pyguide.html
     name: Lint
@@ -51,13 +51,13 @@ jobs:
       run: |
         pip install --editable .[dev]
 
-    - name: Run Black
+    - name: Run ruff format check
       run: |
-        black --check dreem tests
+        ruff format --check dreem tests
 
-    - name: Run pydocstyle
+    - name: Run ruff check
       run: |
-        pydocstyle --convention=google dreem/
+        ruff check dreem
 
   # Tests with pytest
   tests:

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,24 @@
+# Codespell configuration is within pyproject.toml
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Annotate locations with typos
+        uses: codespell-project/codespell-problem-matcher@v1
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,62 @@
+# Docs build
+name: Docs
+
+on:
+  release:
+    types:
+      - published
+  push:
+    paths:
+      - "dreem/**"
+      - "docs/**"
+      - "mkdocs.yml"
+      - ".github/workflows/docs.yml"
+
+jobs:
+  docs:
+    name: Docs
+    runs-on: "ubuntu-latest"
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Setup Conda
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+            miniforge-version: latest
+            conda-solver: "libmamba"
+            environment-file: environment.yml
+            activate-environment: dreem
+
+      - name: Print environment info
+        shell: bash -l {0}
+        run: |
+            which python
+            conda info
+            conda list
+            pip freeze
+
+      - name: Setup Git user
+        run: |
+            git config --global user.name "github-actions[bot]"
+            git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Build and upload docs (release)
+        if: ${{ github.event_name == 'release' && github.event.action == 'published' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash -l {0}
+        run: |
+            mike deploy --update-aliases --allow-empty --push "${{ github.event.release.tag_name }}" latest
+
+      - name: Build and upload docs (dev)
+        if: ${{ github.event_name == 'push' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash -l {0}
+        run: |
+            mike deploy --update-aliases --allow-empty --push dev

--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,6 @@ dreem/training/models/*
 
 # docs
 site/
+
+# Serena MCP
+.serena/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,79 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+### Build, Lint, and Test
+
+- **Run tests**: `pytest`
+- **Run tests with coverage**: `pytest --cov=dreem --cov-report=xml tests/`
+- **Lint code**: `black dreem tests`
+- **Check linting**: `black --check dreem tests`
+- **Check docstring style**: `pydocstyle --convention=google dreem/`
+
+### Development Scripts
+
+- **Train a model**: `dreem-train --config-base=[CONFIG_DIR] --config-name=[CONFIG_STEM]`
+- **Run inference**: `dreem-track --config-base=[CONFIG_DIR] --config-name=[CONFIG_STEM]`
+- **Evaluate model**: `dreem-eval --config-base=[CONFIG_DIR] --config-name=[CONFIG_STEM]`
+- **Visualize results**: `dreem-visualize`
+
+## Architecture Overview
+
+DREEM (Relates Every Entities' Motion) is a Global Tracking Transformer system for biological multi-object tracking. The codebase is organized around three main frameworks:
+
+1. **Hydra** - Configuration management system used throughout for handling YAML configs
+2. **PyTorch** - Core model implementation and tensor operations
+3. **PyTorch Lightning** - High-level training/validation/inference orchestration
+
+### Core Components
+
+- **`dreem/models/`** - Model architecture implementations
+  - `global_tracking_transformer.py` - Main GTR model
+  - `gtr_runner.py` - Lightning module wrapper for training/inference
+  - `visual_encoder.py` - Visual feature extraction (supports timm/torchvision backends)
+  - `transformer.py` - Custom transformer encoder/decoder implementation
+  - `embedding.py` - Spatial and temporal positional embeddings
+
+- **`dreem/datasets/`** - Data loading and preprocessing
+  - `sleap_dataset.py` - For animal pose tracking with SLEAP annotations
+  - `microscopy_dataset.py` - For microscopy cell tracking
+  - `cell_tracking_dataset.py` - For Cell Tracking Challenge format data
+  - `base_dataset.py` - Abstract base class for all datasets
+
+- **`dreem/io/`** - Data structures and I/O utilities
+  - `instance.py` - Core data structure for detected objects
+  - `frame.py` - Frame-level data container
+  - `track.py` - Trajectory representation
+  - `association_matrix.py` - Tracking association logic
+
+- **`dreem/inference/`** - Inference and tracking logic
+  - `tracker.py` - Main tracking algorithm implementation
+  - `batch_tracker.py` - Batched tracking for efficiency
+  - `track_queue.py` - Queue management for sliding window tracking
+
+### Key Design Patterns
+
+1. **Decoupled Detection and Tracking**: The system assumes pre-computed detections (from SLEAP, TrackMate, etc.) and focuses solely on associating them across time.
+
+2. **Sliding Window Inference**: Tracking uses configurable window sizes to handle long videos efficiently while maintaining temporal context.
+
+3. **Multi-anchor Crops**: For pose data, the system can crop around multiple body parts simultaneously to capture more spatial context.
+
+4. **Flexible Visual Encoders**: Supports both timm and torchvision backends with easy swapping via config.
+
+### Configuration System
+
+All training/inference parameters are managed through Hydra configs. Key config sections:
+- `model` - Model architecture parameters
+- `dataset` - Data loading settings
+- `optimizer`/`scheduler` - Training optimization
+- `tracker` - Inference-time tracking parameters
+- `loss` - Loss function configuration
+
+Configs support hierarchical overrides via CLI using dot notation (e.g., `model.nhead=8`).
+
+## GitHub Workflow
+
+- Always use the `gh` CLI to do GitHub related tasks like opening PRs, inspecting issues, and anything that interacts with GitHub. Always prefer using the `gh` CLI over fetching the entire page if URLs with `https://github.com` are provided as part of your task.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Next run:
 ```bash
 conda env create -y -f environment.yml && conda activate dreem
 ```
-This will create a conda environment called `dreem` which will have `dreem` installed as well as any other dependcies needed to run.
+This will create a conda environment called `dreem` which will have `dreem` installed as well as any other dependencies needed to run.
 #### Step 3. Activate the `dreem` environment
 Finally run:
 ```bash
@@ -95,10 +95,10 @@ Once you have your labels file containing the detections and tracks, you'll want
 2. Good detections. Because the input to the model is a crop centered around each detection, we want to make sure the coordinates we crop around are as accurate as possible. This is a bit more arbitrary and up to the user to determine what is a "good" detection. A general rule of thumb is to avoid having detection coordinates be hard to distinguish. For instance, with animal pose estimation, we want to avoid having the key points on two instances. For segmentation, the boundaries should be as tight as possible. This may be unavoidable however, in cases of occlusion and overlap. See below for example cases of good and bad detections.
 //TODO add example good vs bad detection.
 
-We recommend using the [`sleap-label` gui](https://sleap.ai/guides/gui.html) for [proofreading](https://sleap.ai/guides/proofreading.html#id1). This is because SLEAP's in-built gui provides useful. functionality for visualizing detections, moving them, and reassigning tracks. It also provides some nice heuristics for flagging where switches may have occured. 
+We recommend using the [`sleap-label` gui](https://sleap.ai/guides/gui.html) for [proofreading](https://sleap.ai/guides/proofreading.html#id1). This is because SLEAP's in-built gui provides useful. functionality for visualizing detections, moving them, and reassigning tracks. It also provides some nice heuristics for flagging where switches may have occurred. 
 
 ###### Converting data to a SLEAP compatible format.
-In order to use the SLEAP gui you'll need to have your labels and videos in a SLEAP comptabile format. Check out [the sleap-io docs](https://io.sleap.ai/latest/formats/) for available formats. The easiest way to ensure your labels are compatible with sleap is to convert them to a `.slp` file. For animal tracking, if you used SLEAP, this is already how SLEAP saves your labesl so you can start proofreading right away. Otherwise if you used a different system (e.g DeepLabCut) check out [`sleap.io.convert`](https://sleap.ai/api/sleap.io.convert.html#module-sleap.io.convert) for available converters. With microscopy, we highly recommend starting out with TrackMate and then proofread in SLEAP's gui. Here is [a converter from trackmate's output to a `.slp`](https://gist.github.com/aaprasad/5243be0785a40e9dafa1697ce2258e3e) file. In general, you can use [`sleap-io`](https://io.sleap.ai/latest/) to write a custom converter to `.slp` if you'd like to use the sleap-gui for proofreading. Once you've ensured that your labels files have no identity switches and your detections are as good as you're willing to make them, they're ready to use for training.
+In order to use the SLEAP gui you'll need to have your labels and videos in a SLEAP compatible format. Check out [the sleap-io docs](https://io.sleap.ai/latest/formats/) for available formats. The easiest way to ensure your labels are compatible with sleap is to convert them to a `.slp` file. For animal tracking, if you used SLEAP, this is already how SLEAP saves your labesl so you can start proofreading right away. Otherwise if you used a different system (e.g DeepLabCut) check out [`sleap.io.convert`](https://sleap.ai/api/sleap.io.convert.html#module-sleap.io.convert) for available converters. With microscopy, we highly recommend starting out with TrackMate and then proofread in SLEAP's gui. Here is [a converter from trackmate's output to a `.slp`](https://gist.github.com/aaprasad/5243be0785a40e9dafa1697ce2258e3e) file. In general, you can use [`sleap-io`](https://io.sleap.ai/latest/) to write a custom converter to `.slp` if you'd like to use the sleap-gui for proofreading. Once you've ensured that your labels files have no identity switches and your detections are as good as you're willing to make them, they're ready to use for training.
 
 ##### Step 1.3 Organize data.
 
@@ -162,7 +162,7 @@ dreem-train --config-base=/home/aaprasad/dreem_configs --config-name=base
 
 ###### Overriding Arguments
 Instead of changing the `base.yaml` file every time you want to run a different config, `hydra` enables us to either 
-1. provide another `.yaml` file with a subset of the parameters to overide
+1. provide another `.yaml` file with a subset of the parameters to override
 2. provide the args to the cli directly
 
 ###### File-based override
@@ -254,7 +254,7 @@ Similar to training, we need to set up a config file that specifies
 3. a `Tracker` config
 4. a `dataset` config with a `test_dataset` subsection containing dataset params.
 
-Please see the [README](dreem/inference/configs/inference.yaml) in `dreem/inference/configs` for a walk through of the inference params as well as how to set up an inference conifg and see [`dreem/inference/configs/inference.yaml`](dreem/inference/configs/inference.yaml) for an example inference config file.
+Please see the [README](dreem/inference/configs/inference.yaml) in `dreem/inference/configs` for a walk through of the inference params as well as how to set up an inference config and see [`dreem/inference/configs/inference.yaml`](dreem/inference/configs/inference.yaml) for an example inference config file.
 
 #### Step 3 Run Inference
 

--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@
 [![codecov](https://codecov.io/gh/talmolab/dreem/branch/main/graph/badge.svg?token=Sj8kIFl3pi)](https://codecov.io/gh/talmolab/dreem)
 [![Documentation](https://img.shields.io/badge/Documentation-dreem.sleap.ai-lightgrey)](https://dreem.sleap.ai)
 <!-- [![Release](https://img.shields.io/github/v/release/talmolab/dreem?label=Latest)](https://github.com/talmolab/dreem/releases/)
-[![PyPI](https://img.shields.io/pypi/v/dreem?label=PyPI)](https://pypi.org/project/dreem)
-![PyPI - Python Version](https://img.shields.io/pypi/pyversions/dreem) -->
+[![PyPI](https://img.shields.io/pypi/v/dreem-tracker?label=PyPI)](https://pypi.org/project/dreem-tracker)
+![PyPI - Python Version](https://img.shields.io/pypi/pyversions/dreem-tracker) -->
 
 Global Tracking Transformers for biological multi-object tracking.
 
 ## Installation
 <!-- ### Basic
 ```
-pip install dreem
+pip install dreem-tracker
 ``` -->
 ### Development
 #### Clone the repository:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,17 @@
+coverage:
+  status:
+    project:
+      default:
+        # Don't fail CI if project coverage drops
+        informational: true
+    patch:
+      default:
+        # Keep patch coverage requirements
+        target: auto
+        threshold: 10%
+        informational: false
+
+comment:
+  layout: "reach,diff,flags,tree,betaprofiling"
+  behavior: default
+  require_changes: false

--- a/docs/configs/eval.md
+++ b/docs/configs/eval.md
@@ -123,7 +123,7 @@ dataset:
         clip_length: 32
         anchors: ["node1", "node2", ..."node_n"]
         handle_missing: "drop"
-        ... # we don't include augmentations bc usually you shouldnt use augmentations during val/test
+        ... # we don't include augmentations bc usually you shouldn't use augmentations during val/test
 ...
 ```
 #### [`MicroscopyDataset`](../reference/dreem/datasets/microscopy_dataset.md)
@@ -137,7 +137,7 @@ dataset:
         crop_size: 128 
         chunk: True
         clip_length: 32
-        ... # we don't include augmentations bc usually you shouldnt use augmentations during val/test
+        ... # we don't include augmentations bc usually you shouldn't use augmentations during val/test
 ```
 
 ## dataloader

--- a/docs/configs/inference.md
+++ b/docs/configs/inference.md
@@ -130,7 +130,7 @@ dataset:
         clip_length: 32
         anchors: ["node1", "node2", ..."node_n"]
         handle_missing: "drop"
-        ... # we don't include augmentations bc usually you shouldnt use augmentations during val/test
+        ... # we don't include augmentations bc usually you shouldn't use augmentations during val/test
 ...
 ```
 #### [`MicroscopyDataset`](../reference/dreem/datasets/microscopy_dataset.md)
@@ -144,7 +144,7 @@ dataset:
         crop_size: 128 
         chunk: True
         clip_length: 32
-        ... # we don't include augmentations bc usually you shouldnt use augmentations during val/test
+        ... # we don't include augmentations bc usually you shouldn't use augmentations during val/test
 ```
 
 ## dataloader

--- a/docs/configs/training.md
+++ b/docs/configs/training.md
@@ -499,7 +499,7 @@ dataset:
         clip_length: 32
         anchors: ["node1", "node2", ..."node_n"]
         handle_missing: "drop"
-        ... # we don't include augmentations bc usually you shouldnt use augmentations during val/test
+        ... # we don't include augmentations bc usually you shouldn't use augmentations during val/test
     test_dataset:
         slp_files: ["/path/to/test/labels1.slp", "/path/to/test/labels2.slp", ..., "/path/to/test/labelsN.slp"]
         video_files: ["/path/to/test/video1.mp4", "/path/to/test/video2.mp4", ..., "/path/to/test/videoN.mp4"]
@@ -509,7 +509,7 @@ dataset:
         clip_length: 32
         anchors: ["node1", "node2", ..."node_n"]
         handle_missing: "drop"
-        ... # we don't include augmentations bc usually you shouldnt use augmentations during val/test
+        ... # we don't include augmentations bc usually you shouldn't use augmentations during val/test
 ...
 ```
 #### [`MicroscopyDataset`](../reference/dreem/datasets/microscopy_dataset.md)
@@ -540,7 +540,7 @@ dataset:
         crop_size: 128 
         chunk: True
         clip_length: 32
-        ... # we don't include augmentations bc usually you shouldnt use augmentations during val/test
+        ... # we don't include augmentations bc usually you shouldn't use augmentations during val/test
     test_dataset:
         tracks: ["/path/to/test/labels1.csv", "/path/to/test/labels2.csv", ..., "/path/to/test/labelsN.csv"]
         videos: ["/path/to/test/video1.tiff", "/path/to/test/video2.tiff", ..., "/path/to/test/videoN.tiff"]
@@ -549,7 +549,7 @@ dataset:
         crop_size: 128 
         chunk: True
         clip_length: 32
-        ... # we don't include augmentations bc usually you shouldnt use augmentations during val/test
+        ... # we don't include augmentations bc usually you shouldn't use augmentations during val/test
 ```
 ## `dataloader`
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,8 +4,8 @@
 [![codecov](https://codecov.io/gh/talmolab/dreem/branch/main/graph/badge.svg?token=Sj8kIFl3pi)](https://codecov.io/gh/talmolab/dreem)
 [![code](https://img.shields.io/github/stars/talmolab/dreem)](https://github.com/talmolab/dreem)
 <!-- [![Release](https://img.shields.io/github/v/release/talmolab/dreem?label=Latest)](https://github.com/talmolab/dreem/releases/)
-[![PyPI](https://img.shields.io/pypi/v/dreem?label=PyPI)](https://pypi.org/project/dreem)
-![PyPI - Python Version](https://img.shields.io/pypi/pyversions/dreem) -->
+[![PyPI](https://img.shields.io/pypi/v/dreem-tracker?label=PyPI)](https://pypi.org/project/dreem-tracker)
+![PyPI - Python Version](https://img.shields.io/pypi/pyversions/dreem-tracker) -->
 
 
 Welcome to the documentation for **DREEM** – an open-source tool for multiple object tracking. DREEM is a framework that enables you to train your own models, run inference on new data, and evaluate your results. DREEM supports a variety of detection types, including keypoints, bounding boxes, and segmentation masks. You can use any detection model you want, convert the output to a format DREEM can use, and train a model or run inference using a pretrained model.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,6 +1,6 @@
 <!-- ### Basic
 ```bash
-pip install dreem
+pip install dreem-tracker
 ```  
 -->
 #### Clone the repository:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -16,7 +16,7 @@ Head over to the [installation guide](./installation.md) to get started.
 
 ## Training
 
-DREEM enables you to train your own model based on your own annotated data. This can be useful when the pretrained models, or traditional approches to tracking don't work well for your data.
+DREEM enables you to train your own model based on your own annotated data. This can be useful when the pretrained models, or traditional approaches to tracking don't work well for your data.
 
 ### Generate Ground Truth Data
 To train a model, you need:
@@ -44,7 +44,7 @@ Once you have your labels file containing initial detections and tracks, you'll 
 We recommend using the [`sleap-label` GUI](https://sleap.ai/guides/gui.html) for [proofreading](https://sleap.ai/guides/proofreading.html#id1). SLEAP provides tools that make it easy to correct errors in tracking.
 
 ##### Converting data to a SLEAP compatible format
-In order to use the SLEAP GUI you'll need to have your labels and videos in a SLEAP comptabile format. Check out [the sleap-io docs](https://io.sleap.ai/latest/formats/) for available formats. The easiest way to ensure your labels are compatible with sleap is to convert them to a `.slp` file. Otherwise if you used a different system (e.g DeepLabCut) check out [`sleap.io.convert`](https://sleap.ai/api/sleap.io.convert.html#module-sleap.io.convert) for available converters. With microscopy, we highly recommend starting out with TrackMate and then proofread in SLEAP's gui. Here is [a converter from trackmate's output to a `.slp`](https://gist.github.com/aaprasad/5243be0785a40e9dafa1697ce2258e3e) file. In general, you can use [`sleap-io`](https://io.sleap.ai/latest/) to write a custom converter to `.slp` if you'd like to use the sleap-gui for proofreading.
+In order to use the SLEAP GUI you'll need to have your labels and videos in a SLEAP compatible format. Check out [the sleap-io docs](https://io.sleap.ai/latest/formats/) for available formats. The easiest way to ensure your labels are compatible with sleap is to convert them to a `.slp` file. Otherwise if you used a different system (e.g DeepLabCut) check out [`sleap.io.convert`](https://sleap.ai/api/sleap.io.convert.html#module-sleap.io.convert) for available converters. With microscopy, we highly recommend starting out with TrackMate and then proofread in SLEAP's gui. Here is [a converter from trackmate's output to a `.slp`](https://gist.github.com/aaprasad/5243be0785a40e9dafa1697ce2258e3e) file. In general, you can use [`sleap-io`](https://io.sleap.ai/latest/) to write a custom converter to `.slp` if you'd like to use the sleap-gui for proofreading.
 
 #### Organize data
 
@@ -144,7 +144,7 @@ If you've been through the example notebooks, you'll notice that training was do
 ##### Overriding Arguments
 Instead of changing the `base.yaml` file every time you want to train a model using different configurations, `hydra` enables us to either
 
-1. provide another `.yaml` file with a subset of the parameters to overide
+1. provide another `.yaml` file with a subset of the parameters to override
 2. provide the args to the cli directly
 
 We recommend using the file-based override for logging and reproducibility.

--- a/dreem/__init__.py
+++ b/dreem/__init__.py
@@ -1,29 +1,27 @@
 """Top-level package for dreem."""
 
 import logging.config
-from dreem.version import __version__
 
+# from .training import run
+from dreem.inference.tracker import Tracker
+from dreem.io.association_matrix import AssociationMatrix
+from dreem.io.config import Config
+from dreem.io.frame import Frame
+from dreem.io.instance import Instance
+from dreem.io.visualize import annotate_video
 from dreem.models.global_tracking_transformer import GlobalTrackingTransformer
 from dreem.models.gtr_runner import GTRRunner
 from dreem.models.transformer import Transformer
 from dreem.models.visual_encoder import VisualEncoder
-
-from dreem.io.frame import Frame
-from dreem.io.instance import Instance
-from dreem.io.association_matrix import AssociationMatrix
-from dreem.io.config import Config
-from dreem.io.visualize import annotate_video
-
-# from .training import run
-
-from dreem.inference.tracker import Tracker
+from dreem.version import __version__
 
 
 def setup_logging():
     """Setup logging based on `logging.yaml`."""
     import logging
-    import yaml
     import os
+
+    import yaml
 
     package_directory = os.path.dirname(os.path.abspath(__file__))
 

--- a/dreem/__init__.py
+++ b/dreem/__init__.py
@@ -1,7 +1,5 @@
 """Top-level package for dreem."""
 
-import logging.config
-
 # from .training import run
 from dreem.inference.tracker import Tracker
 from dreem.io.association_matrix import AssociationMatrix
@@ -15,10 +13,25 @@ from dreem.models.transformer import Transformer
 from dreem.models.visual_encoder import VisualEncoder
 from dreem.version import __version__
 
+__all__ = [
+    "Tracker",
+    "AssociationMatrix",
+    "Config",
+    "Frame",
+    "Instance",
+    "annotate_video",
+    "GlobalTrackingTransformer",
+    "GTRRunner",
+    "Transformer",
+    "VisualEncoder",
+    "__version__",
+]
+
 
 def setup_logging():
     """Setup logging based on `logging.yaml`."""
     import logging
+    import logging.config
     import os
 
     import yaml
@@ -29,4 +42,3 @@ def setup_logging():
         logging_cfg = yaml.load(stream, Loader=yaml.FullLoader)
 
     logging.config.dictConfig(logging_cfg)
-    logger = logging.getLogger("dreem")

--- a/dreem/datasets/__init__.py
+++ b/dreem/datasets/__init__.py
@@ -5,3 +5,11 @@ from .cell_tracking_dataset import CellTrackingDataset
 from .microscopy_dataset import MicroscopyDataset
 from .sleap_dataset import SleapDataset
 from .tracking_dataset import TrackingDataset
+
+__all__ = [
+    "BaseDataset",
+    "CellTrackingDataset",
+    "MicroscopyDataset",
+    "SleapDataset",
+    "TrackingDataset",
+]

--- a/dreem/datasets/base_dataset.py
+++ b/dreem/datasets/base_dataset.py
@@ -1,12 +1,14 @@
 """Module containing logic for loading datasets."""
 
-from dreem.datasets import data_utils
-from dreem.io import Frame
-from torch.utils.data import Dataset
+import logging
 from typing import Union
+
 import numpy as np
 import torch
-import logging
+from torch.utils.data import Dataset
+
+from dreem.datasets import data_utils
+from dreem.io import Frame
 
 logger = logging.getLogger("dreem.datasets")
 
@@ -113,8 +115,9 @@ class BaseDataset(Dataset):
             for start, end in annotated_segments:
                 # check if the start of current segment is within batching_max_gap of end of previous
                 if (
-                    int(start) - int(prev_end) < self.max_batching_gap
-                ) or not self.chunk:  # also takes care of first segment as start < prev_end
+                    (int(start) - int(prev_end) < self.max_batching_gap)
+                    or not self.chunk
+                ):  # also takes care of first segment as start < prev_end
                     segments_to_stitch.append(torch.arange(start, end + 1))
                     prev_end = end
                 else:
@@ -155,8 +158,7 @@ class BaseDataset(Dataset):
         remove_idx = []
         for i, frame_chunk in enumerate(self.chunked_frame_idx):
             if (
-                len(frame_chunk)
-                <= min(int(self.clip_length / 10), 5)
+                len(frame_chunk) <= min(int(self.clip_length / 10), 5)
                 # and frame_chunk[-1] % self.clip_length == 0
             ):
                 logger.warning(
@@ -206,8 +208,7 @@ class BaseDataset(Dataset):
             remove_idx = []
             for i, frame_chunk in enumerate(self.chunked_frame_idx):
                 if (
-                    len(frame_chunk)
-                    <= min(int(self.clip_length / 10), 5)
+                    len(frame_chunk) <= min(int(self.clip_length / 10), 5)
                     # and frame_chunk[-1] % self.clip_length == 0
                 ):
                     logger.warning(

--- a/dreem/datasets/base_dataset.py
+++ b/dreem/datasets/base_dataset.py
@@ -33,8 +33,8 @@ class BaseDataset(Dataset):
         """Initialize Dataset.
 
         Args:
-            label_files: a list of paths to label files.
-                should at least contain detections for inference, detections + tracks for training.
+            label_files: a list of paths to label files. Should at least contain
+                detections for inference, detections + tracks for training.
             vid_files: list of paths to video files.
             padding: amount of padding around object crops
             crop_size: the size of the object crops
@@ -84,7 +84,9 @@ class BaseDataset(Dataset):
     def process_segments(
         self, i: int, segments_to_stitch: list[torch.Tensor], clip_length: int
     ) -> None:
-        """Process segments to stitch. Modifies state variables chunked_frame_idx and label_idx.
+        """Process segments to stitch.
+        
+        Modifies state variables chunked_frame_idx and label_idx.
 
         Args:
             segments_to_stitch: list of segments to stitch
@@ -162,7 +164,9 @@ class BaseDataset(Dataset):
                 # and frame_chunk[-1] % self.clip_length == 0
             ):
                 logger.warning(
-                    f"Warning: Batch containing frames {frame_chunk} from video {self.vid_files[self.label_idx[i]]} has {len(frame_chunk)} frames. Removing to avoid empty batch possibility with failed frame loading"
+                    f"Warning: Batch containing frames {frame_chunk} from video "
+                    f"{self.vid_files[self.label_idx[i]]} has {len(frame_chunk)} frames. "
+                    f"Removing to avoid empty batch possibility with failed frame loading"
                 )
                 remove_idx.append(i)
         if len(remove_idx) > 0:

--- a/dreem/datasets/base_dataset.py
+++ b/dreem/datasets/base_dataset.py
@@ -115,7 +115,8 @@ class BaseDataset(Dataset):
             segments_to_stitch = []
             prev_end = annotated_segments[0][1]  # end of first segment
             for start, end in annotated_segments:
-                # check if the start of current segment is within batching_max_gap of end of previous
+                # check if the start of current segment is within
+                # batching_max_gap of end of previous
                 if (
                     (int(start) - int(prev_end) < self.max_batching_gap)
                     or not self.chunk
@@ -156,7 +157,9 @@ class BaseDataset(Dataset):
 
             self.label_idx = [self.label_idx[i] for i in sample_idx]
 
-        # workaround for empty batch bug (needs to be changed). Check for batch with with only 1/10 size of clip length. Arbitrary thresholds
+        # workaround for empty batch bug (needs to be changed).
+        # Check for batch with with only 1/10 size of clip length.
+        # Arbitrary thresholds
         remove_idx = []
         for i, frame_chunk in enumerate(self.chunked_frame_idx):
             if (
@@ -208,7 +211,9 @@ class BaseDataset(Dataset):
 
                 self.label_idx = [self.label_idx[i] for i in sample_idx]
 
-            # workaround for empty batch bug (needs to be changed). Check for batch with with only 1/10 size of clip length. Arbitrary thresholds
+            # workaround for empty batch bug (needs to be changed).
+            # Check for batch with with only 1/10 size of clip length.
+            # Arbitrary thresholds
             remove_idx = []
             for i, frame_chunk in enumerate(self.chunked_frame_idx):
                 if (

--- a/dreem/datasets/base_dataset.py
+++ b/dreem/datasets/base_dataset.py
@@ -85,7 +85,7 @@ class BaseDataset(Dataset):
         self, i: int, segments_to_stitch: list[torch.Tensor], clip_length: int
     ) -> None:
         """Process segments to stitch.
-        
+
         Modifies state variables chunked_frame_idx and label_idx.
 
         Args:

--- a/dreem/datasets/cell_tracking_dataset.py
+++ b/dreem/datasets/cell_tracking_dataset.py
@@ -1,18 +1,19 @@
 """Module containing cell tracking challenge dataset."""
 
-from PIL import Image
-from dreem.datasets import data_utils, BaseDataset
-from dreem.io import Frame, Instance
-from scipy.ndimage import measurements
+import random
+from pathlib import Path
+from typing import Optional
+
 import albumentations as A
 import numpy as np
 import pandas as pd
-import random
-import torch
-from typing import Union, Optional
-from pathlib import Path
 import sleap_io as sio
-import matplotlib.pyplot as plt
+import torch
+from PIL import Image
+from scipy.ndimage import measurements
+
+from dreem.datasets import BaseDataset, data_utils
+from dreem.io import Frame, Instance
 
 
 class CellTrackingDataset(BaseDataset):

--- a/dreem/datasets/cell_tracking_dataset.py
+++ b/dreem/datasets/cell_tracking_dataset.py
@@ -49,12 +49,14 @@ class CellTrackingDataset(BaseDataset):
             padding: amount of padding around object crops
             crop_size: the size of the object crops. Can be either:
                 - An integer specifying a single crop size for all objects
-                - A list of integers specifying different crop sizes for different data directories
+                - A list of integers specifying different crop sizes for
+                  different data directories
             chunk: whether or not to chunk the dataset into batches
             clip_length: the number of frames in each chunk
             mode: `train` or `val`. Determines whether this dataset is used for
                 training or validation. Currently doesn't affect dataset logic
-            augmentations: An optional dict mapping augmentations to parameters. The keys
+            augmentations: An optional dict mapping augmentations to parameters.
+                The keys
                 should map directly to augmentation classes in albumentations. Example:
                     augs = {
                         'Rotate': {'limit': [-90, 90]},

--- a/dreem/datasets/cell_tracking_dataset.py
+++ b/dreem/datasets/cell_tracking_dataset.py
@@ -41,8 +41,10 @@ class CellTrackingDataset(BaseDataset):
         """Initialize CellTrackingDataset.
 
         Args:
-            gt_list: filepaths of gt label images in a list of lists (each list corresponds to a dataset)
-            raw_img_list: filepaths of original tif images in a list of lists (each list corresponds to a dataset)
+            gt_list: filepaths of gt label images in a list of lists (each list
+                corresponds to a dataset)
+            raw_img_list: filepaths of original tif images in a list of lists
+                (each list corresponds to a dataset)
             data_dirs: paths to data directories
             padding: amount of padding around object crops
             crop_size: the size of the object crops. Can be either:
@@ -62,9 +64,12 @@ class CellTrackingDataset(BaseDataset):
             n_chunks: Number of chunks to subsample from.
                 Can either a fraction of the dataset (ie (0,1.0]) or number of chunks
             seed: set a seed for reproducibility
-            max_batching_gap: the max number of frames that can be unlabelled before starting a new batch
-            use_tight_bbox: whether to use tight bounding box (around keypoints) instead of the default square bounding box
-            ctc_track_meta: filepaths of man_track.txt files in a list of lists (each list corresponds to a dataset)
+            max_batching_gap: the max number of frames that can be unlabelled
+                before starting a new batch
+            use_tight_bbox: whether to use tight bounding box (around keypoints)
+                instead of the default square bounding box
+            ctc_track_meta: filepaths of man_track.txt files in a list of lists
+                (each list corresponds to a dataset)
             apply_mask_to_crop: whether to apply the mask to the crop
         """
         super().__init__(

--- a/dreem/datasets/cell_tracking_dataset.py
+++ b/dreem/datasets/cell_tracking_dataset.py
@@ -73,6 +73,7 @@ class CellTrackingDataset(BaseDataset):
             ctc_track_meta: filepaths of man_track.txt files in a list of lists
                 (each list corresponds to a dataset)
             apply_mask_to_crop: whether to apply the mask to the crop
+            **kwargs: Additional keyword arguments (unused but accepted for compatibility)
         """
         super().__init__(
             gt_list,

--- a/dreem/datasets/cell_tracking_dataset.py
+++ b/dreem/datasets/cell_tracking_dataset.py
@@ -166,10 +166,11 @@ class CellTrackingDataset(BaseDataset):
         image_paths = self.raw_img_list[label_idx]
         gt_paths = self.gt_list[label_idx]
 
-        if self.list_df_track_meta is not None:
-            df_track_meta = self.list_df_track_meta[label_idx]
-        else:
-            df_track_meta = None
+        # df_track_meta is currently unused but may be needed for future track metadata processing
+        # if self.list_df_track_meta is not None:
+        #     df_track_meta = self.list_df_track_meta[label_idx]
+        # else:
+        #     df_track_meta = None
 
         # get the correct crop size based on the video
         video_par_path = Path(image_paths[0]).parent.parent

--- a/dreem/datasets/data_utils.py
+++ b/dreem/datasets/data_utils.py
@@ -1,30 +1,29 @@
 """Module containing helper functions for datasets."""
 
-from PIL import Image
-from numpy.typing import ArrayLike
-from torchvision.transforms import functional as tvf
-from xml.etree import cElementTree as et
-import albumentations as A
 import math
+from xml.etree import cElementTree as et
+
+import albumentations as A
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import sleap_io as sio
 import torch
-from dreem.io import Instance
-from dreem.io import Instance
+from numpy.typing import ArrayLike
+from PIL import Image
+from sleap_io import LabeledFrame, Labels
 from sleap_io.io.slp import (
     read_hdf5_attrs,
-    read_tracks,
-    read_videos,
-    read_skeletons,
-    read_points,
-    read_pred_points,
+    read_hdf5_dataset,
     read_instances,
     read_metadata,
-    read_hdf5_dataset,
+    read_points,
+    read_pred_points,
+    read_skeletons,
+    read_tracks,
+    read_videos,
 )
-from sleap_io import Labels, LabeledFrame
+from torchvision.transforms import functional as tvf
 
 
 def load_slp(labels_path: str, open_videos: bool = True) -> Labels:

--- a/dreem/datasets/data_utils.py
+++ b/dreem/datasets/data_utils.py
@@ -544,7 +544,7 @@ def parse_synthetic(xml_path: str, source: str = "icy") -> pd.DataFrame:
 
         try:
             ids_map[track_element.attrib["id"]] = track_id
-        except:
+        except KeyError:
             pass
 
         for detection_element in track_element:

--- a/dreem/datasets/data_utils.py
+++ b/dreem/datasets/data_utils.py
@@ -201,7 +201,7 @@ def get_tight_bbox(pose: ArrayLike) -> torch.Tensor:
     """Get a tight bbox around an instance.
 
     Args:
-        poses: array of keypoints around which to create the tight bbox
+        pose: array of keypoints around which to create the tight bbox
 
     Returns:
         A torch tensor in form y1, x1, y2, x2 representing the tight bbox
@@ -661,6 +661,7 @@ def view_training_batch(
         instances: A list of training instances, where each instance is a
             dictionary containing the object crops.
         num_frames: The number of frames to display per instance.
+        cmap: Optional colormap to use for displaying images.
 
     Returns:
         None

--- a/dreem/datasets/microscopy_dataset.py
+++ b/dreem/datasets/microscopy_dataset.py
@@ -1,12 +1,14 @@
 """Module containing microscopy dataset."""
 
-from PIL import Image
-from dreem.datasets import data_utils, BaseDataset
-from dreem.io import Instance, Frame
+import random
+
 import albumentations as A
 import numpy as np
-import random
 import torch
+from PIL import Image
+
+from dreem.datasets import BaseDataset, data_utils
+from dreem.io import Frame, Instance
 
 
 class MicroscopyDataset(BaseDataset):

--- a/dreem/datasets/microscopy_dataset.py
+++ b/dreem/datasets/microscopy_dataset.py
@@ -84,7 +84,8 @@ class MicroscopyDataset(BaseDataset):
         if source.lower() == "trackmate":
             parser = data_utils.parse_trackmate
         elif source.lower() in ["icy", "isbi"]:
-            parser = lambda x: data_utils.parse_synthetic(x, source=source)
+            def parser(x):
+                return data_utils.parse_synthetic(x, source=source)
         else:
             raise ValueError(
                 f"{source} is unsupported! Must be one of [trackmate, icy, isbi]"

--- a/dreem/datasets/microscopy_dataset.py
+++ b/dreem/datasets/microscopy_dataset.py
@@ -84,6 +84,7 @@ class MicroscopyDataset(BaseDataset):
         if source.lower() == "trackmate":
             parser = data_utils.parse_trackmate
         elif source.lower() in ["icy", "isbi"]:
+
             def parser(x):
                 return data_utils.parse_synthetic(x, source=source)
         else:

--- a/dreem/datasets/sleap_dataset.py
+++ b/dreem/datasets/sleap_dataset.py
@@ -1,17 +1,19 @@
 """Module containing logic for loading sleap datasets."""
 
+import logging
+import random
+from pathlib import Path
+from typing import Optional, Union
+
 import albumentations as A
-import torch
 import imageio
 import numpy as np
 import sleap_io as sio
-import random
-from pathlib import Path
-import logging
-from typing import Union, Optional
-from dreem.io import Instance, Frame
-from dreem.datasets import data_utils, BaseDataset
+import torch
 from torchvision.transforms import functional as tvf
+
+from dreem.datasets import BaseDataset, data_utils
+from dreem.io import Frame, Instance
 
 logger = logging.getLogger("dreem.datasets")
 

--- a/dreem/datasets/sleap_dataset.py
+++ b/dreem/datasets/sleap_dataset.py
@@ -80,6 +80,7 @@ class SleapDataset(BaseDataset):
             normalize_image: whether to normalize the image to [0, 1]
             max_batching_gap: the max number of frames that can be unlabelled before starting a new batch
             use_tight_bbox: whether to use tight bounding box (around keypoints) instead of the default square bounding box
+            **kwargs: Additional keyword arguments (unused but accepted for compatibility)
         """
         super().__init__(
             slp_files,

--- a/dreem/datasets/tracking_dataset.py
+++ b/dreem/datasets/tracking_dataset.py
@@ -1,12 +1,12 @@
 """Module containing Lightning module wrapper around all other datasets."""
 
+import torch
+from pytorch_lightning import LightningDataModule
+from torch.utils.data import DataLoader
+
 from dreem.datasets.cell_tracking_dataset import CellTrackingDataset
 from dreem.datasets.microscopy_dataset import MicroscopyDataset
 from dreem.datasets.sleap_dataset import SleapDataset
-from pytorch_lightning import LightningDataModule
-from torch.utils.data import DataLoader
-import torch
-
 
 """
 Lightning wrapper for tracking datasets

--- a/dreem/inference/__init__.py
+++ b/dreem/inference/__init__.py
@@ -2,3 +2,8 @@
 
 from .batch_tracker import BatchTracker
 from .tracker import Tracker
+
+__all__ = [
+    "BatchTracker",
+    "Tracker",
+]

--- a/dreem/inference/__init__.py
+++ b/dreem/inference/__init__.py
@@ -1,4 +1,4 @@
 """Tracking Inference using GTR Model."""
 
-from .tracker import Tracker
 from .batch_tracker import BatchTracker
+from .tracker import Tracker

--- a/dreem/inference/batch_tracker.py
+++ b/dreem/inference/batch_tracker.py
@@ -183,8 +183,6 @@ class BatchTracker:
                 [frame.frame_id] * len(frame.instances)
             )
 
-        frames_to_track = context_window_frames + frames
-
         # query is current batch instances, key is context window and current batch instances
         association_matrix = model(
             context_window_instances + current_batch_instances, current_batch_instances
@@ -260,8 +258,6 @@ class BatchTracker:
                     frames_to_track = context_window_frames + [
                         frame_to_track
                     ]  # better var name?
-
-                    query_ind = len(frames_to_track) - 1
 
                     frame_to_track = self._run_frame_by_frame_tracker(
                         model,

--- a/dreem/inference/batch_tracker.py
+++ b/dreem/inference/batch_tracker.py
@@ -50,6 +50,7 @@ class BatchTracker:
             max_tracks: the maximum number of tracks that can be created while tracking.
                 We force the tracker to assign instances to a track instead of creating a new track if max_tracks has been reached.
             verbose: Whether or not to turn on debug printing after each operation.
+            **kwargs: Additional keyword arguments (unused but accepted for compatibility).
         """
         self.track_queue = TrackQueue(
             window_size=window_size, max_gap=max_gap, verbose=verbose

--- a/dreem/inference/boxes.py
+++ b/dreem/inference/boxes.py
@@ -1,7 +1,8 @@
 """Module containing Boxes class."""
 
-import torch
 from typing import Self
+
+import torch
 
 
 class Boxes:
@@ -124,9 +125,9 @@ class Boxes:
         if isinstance(item, int):
             return Boxes(self.tensor[item])
         b = self.tensor[item]
-        assert (
-            b.dim() == 3
-        ), "Indexing on Boxes with {} failed to return a matrix!".format(item)
+        assert b.dim() == 3, (
+            "Indexing on Boxes with {} failed to return a matrix!".format(item)
+        )
         return Boxes(b)
 
     def __len__(self) -> int:

--- a/dreem/inference/configs/README.md
+++ b/dreem/inference/configs/README.md
@@ -116,7 +116,7 @@ dataset:
         clip_length: 32
         anchors: ["node1", "node2", ..."node_n"]
         handle_missing: "drop"
-        ... # we don't include augmentations bc usually you shouldnt use augmentations during val/test
+        ... # we don't include augmentations bc usually you shouldn't use augmentations during val/test
 ...
 ```
 #### [`MicroscopyDataset`](../../datasets/microscopy_dataset.py)
@@ -130,7 +130,7 @@ dataset:
         crop_size: 128 
         chunk: True
         clip_length: 32
-        ... # we don't include augmentations bc usually you shouldnt use augmentations during val/test
+        ... # we don't include augmentations bc usually you shouldn't use augmentations during val/test
 ```
 
 ## [dataloader](inference.yaml#L18-21)

--- a/dreem/inference/eval.py
+++ b/dreem/inference/eval.py
@@ -72,7 +72,7 @@ def run(cfg: DictConfig) -> dict[int, sio.Labels]:
             label_files=[label_file], vid_files=[vid_file], mode="test"
         )
         dataloader = eval_cfg.get_dataloader(dataset, mode="test")
-        metrics = trainer.test(model, dataloader)
+        _ = trainer.test(model, dataloader)
 
 
 if __name__ == "__main__":

--- a/dreem/inference/eval.py
+++ b/dreem/inference/eval.py
@@ -1,18 +1,16 @@
 """Script to evaluate model."""
 
-from dreem.io import Config
-from dreem.models import GTRRunner
-from dreem.inference import Tracker, BatchTracker
-from omegaconf import DictConfig
-from pathlib import Path
+import logging
+import os
 
 import hydra
-import os
 import pandas as pd
-import pytorch_lightning as pl
-import torch
 import sleap_io as sio
-import logging
+from omegaconf import DictConfig
+
+from dreem.inference import BatchTracker, Tracker
+from dreem.io import Config
+from dreem.models import GTRRunner
 
 logger = logging.getLogger("dreem.inference")
 if not logger.handlers:
@@ -53,11 +51,11 @@ def run(cfg: DictConfig) -> dict[int, sio.Labels]:
         model.tracker = BatchTracker(**model.tracker_cfg)
     else:
         model.tracker = Tracker(**model.tracker_cfg)
-    logger.info(f"Using the following tracker:")
+    logger.info("Using the following tracker:")
     logger.info(model.tracker)
     model.metrics["test"] = eval_cfg.get("metrics", {}).get("test", "all")
     model.persistent_tracking["test"] = True
-    logger.info(f"Computing the following metrics:")
+    logger.info("Computing the following metrics:")
     logger.info(model.metrics["test"])
     model.test_results["save_path"] = eval_cfg.get("outdir", ".")
     os.makedirs(model.test_results["save_path"], exist_ok=True)

--- a/dreem/inference/metrics.py
+++ b/dreem/inference/metrics.py
@@ -1,15 +1,19 @@
 """Helper functions for calculating mot metrics."""
 
 import logging
+from typing import TYPE_CHECKING
 
 import motmetrics as mm
 import numpy as np
 import pandas as pd
 
+if TYPE_CHECKING:
+    from dreem.io import Frame
+
 logger = logging.getLogger("dreem.inference")
 
 
-def get_matches(frames: list["dreem.io.Frame"]) -> tuple[dict, list, int]:
+def get_matches(frames: list["Frame"]) -> tuple[dict, list, int]:
     """Get comparison between predicted and gt trajectory labels. Deprecated.
 
     Args:

--- a/dreem/inference/metrics.py
+++ b/dreem/inference/metrics.py
@@ -168,7 +168,7 @@ def compute_motmetrics(df):
         if (pred_tracks == -1).all():
             pred_tracks = np.full(len(gt_ids), np.nan)
 
-        expected_tm_ids = []
+        # expected_tm_ids = []  # Currently unused but may be needed for future TRA metric calculations
         cost_gt_dreem = np.full((len(gt_ids), len(gt_ids)), np.nan)
         np.fill_diagonal(cost_gt_dreem, 1)
         acc_dreem.update(

--- a/dreem/inference/metrics.py
+++ b/dreem/inference/metrics.py
@@ -1,11 +1,10 @@
 """Helper functions for calculating mot metrics."""
 
-import numpy as np
-import motmetrics as mm
-import torch
-import pandas as pd
 import logging
-from typing import Iterable
+
+import motmetrics as mm
+import numpy as np
+import pandas as pd
 
 logger = logging.getLogger("dreem.inference")
 

--- a/dreem/inference/metrics.py
+++ b/dreem/inference/metrics.py
@@ -51,7 +51,7 @@ def get_switches(matches: dict, indices: list) -> dict:
         indices: a list of frame indices being used
 
     Returns:
-        A dict of dicts containing the frame at which the switch occured
+        A dict of dicts containing the frame at which the switch occurred
         and the change in labels
     """
     track, switches = {}, {}

--- a/dreem/inference/post_processing.py
+++ b/dreem/inference/post_processing.py
@@ -49,7 +49,8 @@ def _pairwise_intersection(boxes1: Boxes, boxes2: Boxes) -> torch.Tensor:
     The box order must be (xmin, ymin, xmax, ymax)
 
     Args:
-        boxes1,boxes2 (Boxes): two `Boxes`. Contains N & M boxes, respectively.
+        boxes1: First set of boxes (Boxes object containing N boxes).
+        boxes2: Second set of boxes (Boxes object containing M boxes).
 
     Returns:
         Tensor: intersection, sized [N,M].
@@ -71,7 +72,8 @@ def _pairwise_iou(boxes1: Boxes, boxes2: Boxes) -> torch.Tensor:
     The box order must be (xmin, ymin, xmax, ymax).
 
     Args:
-        boxes1,boxes2 (Boxes): two `Boxes`. Contains N & M boxes, respectively.
+        boxes1: First set of boxes (Boxes object containing N boxes).
+        boxes2: Second set of boxes (Boxes object containing M boxes).
 
     Returns:
         Tensor: IoU, sized [N,M].

--- a/dreem/inference/post_processing.py
+++ b/dreem/inference/post_processing.py
@@ -1,6 +1,7 @@
 """Helper functions for post-processing association matrix pre-tracking."""
 
 import torch
+
 from dreem.inference.boxes import Boxes
 
 
@@ -25,9 +26,9 @@ def weight_decay_time(
     Returns: The N_t x N association matrix weighted by decay time
     """
     if decay_time is not None and decay_time > 0:
-        assert (
-            reid_features is not None and T is not None and k is not None
-        ), "Need reid_features to weight traj_score by `decay_time`!"
+        assert reid_features is not None and T is not None and k is not None, (
+            "Need reid_features to weight traj_score by `decay_time`!"
+        )
         N_t = asso_output.shape[0]
         dts = torch.cat(
             [
@@ -140,9 +141,9 @@ def filter_max_center_dist(
         An N_t x N association matrix
     """
     if max_center_dist is not None and max_center_dist > 0:
-        assert (
-            query_boxes_px is not None and nonquery_boxes_px is not None
-        ), "Need `query_boxes_px`, and `nonquery_boxes_px` to filter by `max_center_dist`"
+        assert query_boxes_px is not None and nonquery_boxes_px is not None, (
+            "Need `query_boxes_px`, and `nonquery_boxes_px` to filter by `max_center_dist`"
+        )
 
         k_ct = (query_boxes_px[:, :, :2] + query_boxes_px[:, :, 2:]) / 2
         # k_s = ((curr_frame_boxes[:, :, 2:] - curr_frame_boxes[:, :, :2]) ** 2).sum(dim=2)  # n_k

--- a/dreem/inference/track.py
+++ b/dreem/inference/track.py
@@ -1,22 +1,23 @@
 """Script to run inference and get out tracks."""
 
-from dreem.io import Config
-from dreem.inference import Tracker, BatchTracker
-from dreem.models import GTRRunner
-from dreem.datasets import CellTrackingDataset
-from omegaconf import DictConfig
-from pathlib import Path
+import logging
+import os
 from datetime import datetime
+from pathlib import Path
 
 import hydra
-import os
+import numpy as np
 import pandas as pd
 import pytorch_lightning as pl
-import torch
 import sleap_io as sio
-import logging
-import numpy as np
 import tifffile
+import torch
+from omegaconf import DictConfig
+
+from dreem.datasets import CellTrackingDataset
+from dreem.inference import BatchTracker, Tracker
+from dreem.io import Config
+from dreem.models import GTRRunner
 
 logger = logging.getLogger("dreem.inference")
 
@@ -163,7 +164,7 @@ def run(cfg: DictConfig) -> dict[int, sio.Labels]:
         model.tracker = BatchTracker(**model.tracker_cfg)
     else:
         model.tracker = Tracker(**model.tracker_cfg)
-    logger.info(f"Using the following tracker:")
+    logger.info("Using the following tracker:")
     logger.info(model.tracker)
 
     labels_files, vid_files = pred_cfg.get_data_paths(

--- a/dreem/inference/track.py
+++ b/dreem/inference/track.py
@@ -87,7 +87,7 @@ def track_ctc(
         for frame in batch:
             frame_masks = []
             for instance in frame.instances:
-                centroid = instance.centroid["centroid"]
+                # centroid = instance.centroid["centroid"]  # Currently unused but available if needed
                 mask = instance.mask.cpu().numpy()
                 track_id = instance.pred_track_id.cpu().numpy().item()
                 mask = mask.astype(np.uint8)

--- a/dreem/inference/track.py
+++ b/dreem/inference/track.py
@@ -16,7 +16,7 @@ from omegaconf import DictConfig
 
 from dreem.datasets import CellTrackingDataset
 from dreem.inference import BatchTracker, Tracker
-from dreem.io import Config
+from dreem.io import Config, Frame
 from dreem.models import GTRRunner
 
 logger = logging.getLogger("dreem.inference")
@@ -33,7 +33,7 @@ def get_timestamp() -> str:
 
 
 def export_trajectories(
-    frames_pred: list["dreem.io.Frame"], save_path: str | None = None
+    frames_pred: list[Frame], save_path: str | None = None
 ) -> pd.DataFrame:
     """Convert trajectories to data frame and save as .csv.
 

--- a/dreem/inference/track_queue.py
+++ b/dreem/inference/track_queue.py
@@ -1,12 +1,12 @@
 """Module handling sliding window tracking."""
 
-from dreem.io import Frame
-from collections import deque
-from torch import device
-
 import logging
+from collections import deque
+
 import numpy as np
 from torch import device
+
+from dreem.io import Frame
 
 logger = logging.getLogger("dreem.inference")
 
@@ -60,7 +60,7 @@ class TrackQueue:
             f"max_gap={self.max_gap}, "
             f"n_tracks={self.n_tracks}, "
             f"curr_track={self.curr_track}, "
-            f"queues={[(key,len(queue)) for key, queue in self._queues.items()]}, "
+            f"queues={[(key, len(queue)) for key, queue in self._queues.items()]}, "
             f"curr_gap:{self._curr_gap}"
             ")"
         )

--- a/dreem/inference/tracker.py
+++ b/dreem/inference/tracker.py
@@ -50,6 +50,7 @@ class Tracker:
             max_tracks: the maximum number of tracks that can be created while tracking.
                 We force the tracker to assign instances to a track instead of creating a new track if max_tracks has been reached.
             verbose: Whether or not to turn on debug printing after each operation.
+            **kwargs: Additional keyword arguments (unused but accepted for compatibility).
         """
         self.track_queue = TrackQueue(
             window_size=window_size, max_gap=max_gap, verbose=verbose

--- a/dreem/inference/tracker.py
+++ b/dreem/inference/tracker.py
@@ -1,16 +1,17 @@
 """Module containing logic for going from association -> assignment."""
 
-import torch
-import pandas as pd
 import logging
+from math import inf
 
-from dreem.io import Frame
-from dreem.models import model_utils, GlobalTrackingTransformer
-from dreem.inference.track_queue import TrackQueue
+import pandas as pd
+import torch
+from scipy.optimize import linear_sum_assignment
+
 from dreem.inference import post_processing
 from dreem.inference.boxes import Boxes
-from scipy.optimize import linear_sum_assignment
-from math import inf
+from dreem.inference.track_queue import TrackQueue
+from dreem.io import Frame
+from dreem.models import GlobalTrackingTransformer, model_utils
 
 logger = logging.getLogger("dreem.inference")
 
@@ -142,7 +143,7 @@ class Tracker:
         instances_pred = self.sliding_inference(model, frames)
 
         if not self.persistent_tracking:
-            logger.debug(f"Clearing Queue after tracking")
+            logger.debug("Clearing Queue after tracking")
             self.track_queue.end_tracks()
 
         return instances_pred
@@ -174,7 +175,6 @@ class Tracker:
             if (
                 self.persistent_tracking and frame_to_track.frame_id == 0
             ):  # check for new video and clear queue
-
                 logger.debug("New Video! Resetting Track Queue.")
                 self.track_queue.end_tracks()
 
@@ -183,7 +183,6 @@ class Tracker:
             """
             if len(self.track_queue) == 0:
                 if frame_to_track.has_instances():
-
                     logger.debug(
                         f"Initializing track on clip ind {batch_idx} frame {frame_to_track.frame_id.item()}"
                     )
@@ -199,9 +198,7 @@ class Tracker:
                             instance.pred_track_id = curr_track_id
 
             else:
-                if (
-                    frame_to_track.has_instances()
-                ):  # Check if there are detections. If there are skip and increment gap count
+                if frame_to_track.has_instances():  # Check if there are detections. If there are skip and increment gap count
                     frames_to_track = tracked_frames + [
                         frame_to_track
                     ]  # better var name?
@@ -263,8 +260,9 @@ class Tracker:
 
         instances_per_frame = [frame.num_detected for frame in frames]
 
-        total_instances, window_size = sum(instances_per_frame), len(
-            instances_per_frame
+        total_instances, window_size = (
+            sum(instances_per_frame),
+            len(instances_per_frame),
         )  # Number of instances in window; length of window.
 
         logger.debug(f"total_instances: {total_instances}")
@@ -319,9 +317,7 @@ class Tracker:
                 if batch_idx != query_ind
             ],
             dim=0,
-        ).view(
-            n_nonquery
-        )  # (n_nonquery,)
+        ).view(n_nonquery)  # (n_nonquery,)
 
         query_inds = [
             x
@@ -414,9 +410,7 @@ class Tracker:
 
             last_inds = (
                 id_inds * torch.arange(n_nonquery, device=id_inds.device)[:, None]
-            ).max(dim=0)[
-                1
-            ]  # M
+            ).max(dim=0)[1]  # M
 
             last_boxes = nonquery_boxes[last_inds]  # n_traj x 4
             last_ious = post_processing._pairwise_iou(

--- a/dreem/io/__init__.py
+++ b/dreem/io/__init__.py
@@ -5,3 +5,11 @@ from dreem.io.config import Config
 from dreem.io.frame import Frame
 from dreem.io.instance import Instance
 from dreem.io.track import Track
+
+__all__ = [
+    "AssociationMatrix",
+    "Config",
+    "Frame",
+    "Instance",
+    "Track",
+]

--- a/dreem/io/__init__.py
+++ b/dreem/io/__init__.py
@@ -1,7 +1,7 @@
 """Module containing input/output data structures for easy storage and manipulation."""
 
+from dreem.io.association_matrix import AssociationMatrix
+from dreem.io.config import Config
 from dreem.io.frame import Frame
 from dreem.io.instance import Instance
-from dreem.io.association_matrix import AssociationMatrix
 from dreem.io.track import Track
-from dreem.io.config import Config

--- a/dreem/io/association_matrix.py
+++ b/dreem/io/association_matrix.py
@@ -1,11 +1,13 @@
 """Module containing class for storing and looking up association scores."""
 
-import torch
-import numpy as np
-import pandas as pd
-import attrs
 import logging
 from typing import Self
+
+import attrs
+import numpy as np
+import pandas as pd
+import torch
+
 from dreem.io import Instance
 
 logger = logging.getLogger("dreem.io")
@@ -114,7 +116,7 @@ class AssociationMatrix:
             else:
                 raise ValueError(
                     (
-                        f"Mismatched # of rows and labels!",
+                        "Mismatched # of rows and labels!",
                         f"Found {len(row_labels)} with {len(self.query_instances)} rows",
                     )
                 )
@@ -140,7 +142,7 @@ class AssociationMatrix:
             else:
                 raise ValueError(
                     (
-                        f"Mismatched # of columns and labels!",
+                        "Mismatched # of columns and labels!",
                         f"Found {len(col_labels)} with {len(self.ref_instances)} columns",
                     )
                 )
@@ -207,7 +209,6 @@ class AssociationMatrix:
         reduced_matrix = []
         for row_track, row_instances in row_tracks.items():
             for col_track, col_instances in col_tracks.items():
-
                 asso_matrix = self[row_instances, col_instances]
 
                 if col_dims == "track":

--- a/dreem/io/association_matrix.py
+++ b/dreem/io/association_matrix.py
@@ -8,7 +8,7 @@ import numpy as np
 import pandas as pd
 import torch
 
-from dreem.io import Instance
+from dreem.io.instance import Instance
 
 logger = logging.getLogger("dreem.io")
 

--- a/dreem/io/config.py
+++ b/dreem/io/config.py
@@ -7,11 +7,16 @@ import glob
 import logging
 import os
 from pathlib import Path
-from typing import Iterable
+from typing import TYPE_CHECKING, Iterable
 
 import pytorch_lightning as pl
 import torch
 from omegaconf import DictConfig, OmegaConf, open_dict
+
+if TYPE_CHECKING:
+    from dreem.datasets import CellTrackingDataset, MicroscopyDataset, SleapDataset
+    from dreem.models import GlobalTrackingTransformer, GTRRunner
+    from dreem.training.losses import AssoLoss
 
 logger = logging.getLogger("dreem.io")
 
@@ -108,7 +113,7 @@ class Config:
 
         return param
 
-    def get_model(self) -> "GlobalTrackingTransformer":
+    def get_model(self) -> GlobalTrackingTransformer:
         """Getter for gtr model.
 
         Returns:
@@ -133,7 +138,7 @@ class Config:
         """
         return self.get("tracker", {})
 
-    def get_gtr_runner(self, ckpt_path: str | None = None) -> "GTRRunner":
+    def get_gtr_runner(self, ckpt_path: str | None = None) -> GTRRunner:
         """Get lightning module for training, validation, and inference.
 
         Args:
@@ -271,7 +276,7 @@ class Config:
         mode: str,
         label_files: list[str] | None = None,
         vid_files: list[str | list[str]] = None,
-    ) -> "SleapDataset" | "CellTrackingDataset":
+    ) -> SleapDataset | CellTrackingDataset:
         """Getter for datasets.
 
         Args:
@@ -367,7 +372,7 @@ class Config:
 
     def get_dataloader(
         self,
-        dataset: "SleapDataset" | "MicroscopyDataset" | "CellTrackingDataset",
+        dataset: SleapDataset | MicroscopyDataset | CellTrackingDataset,
         mode: str,
     ) -> torch.utils.data.DataLoader:
         """Getter for dataloader.
@@ -444,7 +449,7 @@ class Config:
             return None
         return init_scheduler(optimizer, lr_scheduler_params)
 
-    def get_loss(self) -> "dreem.training.losses.AssoLoss":
+    def get_loss(self) -> AssoLoss:
         """Getter for loss functions.
 
         Returns:

--- a/dreem/io/config.py
+++ b/dreem/io/config.py
@@ -2,14 +2,16 @@
 """Data structures for handling config parsing."""
 
 from __future__ import annotations
-from omegaconf import DictConfig, OmegaConf, open_dict
-from typing import Iterable
-from pathlib import Path
-import logging
+
 import glob
+import logging
 import os
+from pathlib import Path
+from typing import Iterable
+
 import pytorch_lightning as pl
 import torch
+from omegaconf import DictConfig, OmegaConf, open_dict
 
 logger = logging.getLogger("dreem.io")
 
@@ -281,7 +283,7 @@ class Config:
         Returns:
             Either a `SleapDataset` or `CellTrackingDataset` with params indicated by cfg
         """
-        from dreem.datasets import SleapDataset, CellTrackingDataset
+        from dreem.datasets import CellTrackingDataset, SleapDataset
 
         dataset_params = self.get("dataset")
         if dataset_params is None:

--- a/dreem/io/frame.py
+++ b/dreem/io/frame.py
@@ -1,14 +1,16 @@
 """Module containing data classes such as Instances and Frames."""
 
 from __future__ import annotations
-from numpy.typing import ArrayLike
-from typing import Self
-import torch
-import sleap_io as sio
-import numpy as np
-import attrs
+
 import logging
+from typing import Self
+
+import attrs
 import h5py
+import numpy as np
+import sleap_io as sio
+import torch
+from numpy.typing import ArrayLike
 
 logger = logging.getLogger("dreem.io")
 

--- a/dreem/io/frame.py
+++ b/dreem/io/frame.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Self
+from typing import TYPE_CHECKING, Self
 
 import attrs
 import h5py
@@ -11,6 +11,9 @@ import numpy as np
 import sleap_io as sio
 import torch
 from numpy.typing import ArrayLike
+
+if TYPE_CHECKING:
+    from dreem.io import AssociationMatrix, Instance
 
 logger = logging.getLogger("dreem.io")
 
@@ -61,8 +64,8 @@ class Frame:
         alias="img_shape", converter=_to_tensor, factory=list
     )
 
-    _instances: list["Instance"] = attrs.field(alias="instances", factory=list)
-    _asso_output: "AssociationMatrix" | None = attrs.field(
+    _instances: list[Instance] = attrs.field(alias="instances", factory=list)
+    _asso_output: AssociationMatrix | None = attrs.field(
         alias="asso_output", default=None
     )
     _matches: tuple = attrs.field(alias="matches", factory=tuple)
@@ -371,7 +374,7 @@ class Frame:
         self._img_shape = _to_tensor(img_shape)
 
     @property
-    def instances(self) -> list["Instance"]:
+    def instances(self) -> list[Instance]:
         """A list of instances in the frame.
 
         Returns:
@@ -380,7 +383,7 @@ class Frame:
         return self._instances
 
     @instances.setter
-    def instances(self, instances: list["Instance"]) -> None:
+    def instances(self, instances: list[Instance]) -> None:
         """Set the frame's instance.
 
         Args:
@@ -410,7 +413,7 @@ class Frame:
         return len(self.instances)
 
     @property
-    def asso_output(self) -> "AssociationMatrix":
+    def asso_output(self) -> AssociationMatrix:
         """The association matrix between instances outputted directly by transformer.
 
         Returns:
@@ -429,7 +432,7 @@ class Frame:
         return True
 
     @asso_output.setter
-    def asso_output(self, asso_output: "AssociationMatrix") -> None:
+    def asso_output(self, asso_output: AssociationMatrix) -> None:
         """Set the association matrix of a frame.
 
         Args:

--- a/dreem/io/frame.py
+++ b/dreem/io/frame.py
@@ -64,7 +64,7 @@ class Frame:
         alias="img_shape", converter=_to_tensor, factory=list
     )
 
-    _instances: list[Instance] = attrs.field(alias="instances", factory=list)
+    _instances: list["Instance"] = attrs.field(alias="instances", factory=list)
     _asso_output: AssociationMatrix | None = attrs.field(
         alias="asso_output", default=None
     )
@@ -377,7 +377,7 @@ class Frame:
         self._img_shape = _to_tensor(img_shape)
 
     @property
-    def instances(self) -> list[Instance]:
+    def instances(self) -> list["Instance"]:
         """A list of instances in the frame.
 
         Returns:
@@ -386,7 +386,7 @@ class Frame:
         return self._instances
 
     @instances.setter
-    def instances(self, instances: list[Instance]) -> None:
+    def instances(self, instances: list["Instance"]) -> None:
         """Set the frame's instance.
 
         Args:

--- a/dreem/io/frame.py
+++ b/dreem/io/frame.py
@@ -145,6 +145,9 @@ class Frame:
 
         Args:
             lf: A sio.LabeledFrame object
+            video_id: The ID of the video containing this frame.
+            device: The device to use for tensor operations.
+            **kwargs: Additional keyword arguments passed to Instance creation.
 
         Returns:
             A dreem.io.Frame object

--- a/dreem/io/frame.py
+++ b/dreem/io/frame.py
@@ -146,7 +146,7 @@ class Frame:
         Returns:
             A dreem.io.Frame object
         """
-        from dreem.io import Instance
+        from dreem.io.instance import Instance
 
         img_shape = lf.image.shape
         if len(img_shape) == 2:

--- a/dreem/io/frame.py
+++ b/dreem/io/frame.py
@@ -411,7 +411,7 @@ class Frame:
 
     @property
     def asso_output(self) -> "AssociationMatrix":
-        """The association matrix between instances outputed directly by transformer.
+        """The association matrix between instances outputted directly by transformer.
 
         Returns:
             An arraylike (n_query, n_nonquery) association matrix between instances.
@@ -439,7 +439,7 @@ class Frame:
 
     @property
     def matches(self) -> tuple:
-        """Matches between frame instances and availabel trajectories.
+        """Matches between frame instances and available trajectories.
 
         Returns:
             A tuple containing the instance idx and trajectory idx for the matched instance.

--- a/dreem/io/instance.py
+++ b/dreem/io/instance.py
@@ -1,7 +1,7 @@
 """Module containing data class for storing detections."""
 
 import logging
-from typing import TYPE_CHECKING, Any, Self
+from typing import TYPE_CHECKING, Any, Optional, Self
 
 import attrs
 import h5py
@@ -102,7 +102,7 @@ class Instance:
     )
     _pose: dict[str, ArrayLike] = attrs.field(alias="pose", factory=dict)
     _device: str | torch.device | None = attrs.field(alias="device", default=None)
-    _frame: "Frame" | None = None
+    _frame: Optional["Frame"] = None
 
     def __attrs_post_init__(self) -> None:
         """Handle dimensionality and more intricate default initializations post-init."""

--- a/dreem/io/instance.py
+++ b/dreem/io/instance.py
@@ -42,6 +42,7 @@ def _expand_to_rank(
 
     Args:
         arr: an n-dimensional array (either np.ndarray or torch.Tensor).
+        new_rank: The target rank (number of dimensions) for the array.
 
     Returns:
         The array expanded to the correct dimensions.

--- a/dreem/io/instance.py
+++ b/dreem/io/instance.py
@@ -681,7 +681,7 @@ class Instance:
     def point_scores(self) -> ArrayLike:
         """Get the point scores associated with the pose prediction.
 
-        Returns: a vector of shape n containing the point scores outputed from sleap associated with pose predictions.
+        Returns: a vector of shape n containing the point scores outputted from sleap associated with pose predictions.
         """
         return self._point_scores
 

--- a/dreem/io/instance.py
+++ b/dreem/io/instance.py
@@ -601,7 +601,7 @@ class Instance:
         self._embeddings[emb_type] = embedding
 
     @property
-    def frame(self) -> Frame:
+    def frame(self) -> "Frame":
         """Get the frame the instance belongs to.
 
         Returns:
@@ -610,7 +610,7 @@ class Instance:
         return self._frame
 
     @frame.setter
-    def frame(self, frame: Frame) -> None:
+    def frame(self, frame: "Frame") -> None:
         """Set the back reference to the `Frame` that this `Instance` belongs to.
 
         This field is set when instances are added to `Frame` object.

--- a/dreem/io/instance.py
+++ b/dreem/io/instance.py
@@ -102,7 +102,7 @@ class Instance:
     )
     _pose: dict[str, ArrayLike] = attrs.field(alias="pose", factory=dict)
     _device: str | torch.device | None = attrs.field(alias="device", default=None)
-    _frame: Frame | None = None
+    _frame: "Frame" | None = None
 
     def __attrs_post_init__(self) -> None:
         """Handle dimensionality and more intricate default initializations post-init."""

--- a/dreem/io/instance.py
+++ b/dreem/io/instance.py
@@ -1,13 +1,14 @@
 """Module containing data class for storing detections."""
 
-import torch
-import sleap_io as sio
-import numpy as np
-import attrs
 import logging
+from typing import Any, Self
+
+import attrs
 import h5py
+import numpy as np
+import sleap_io as sio
+import torch
 from numpy.typing import ArrayLike
-from typing import Self, Any
 
 logger = logging.getLogger("dreem.io")
 

--- a/dreem/io/instance.py
+++ b/dreem/io/instance.py
@@ -1,7 +1,7 @@
 """Module containing data class for storing detections."""
 
 import logging
-from typing import Any, Self
+from typing import TYPE_CHECKING, Any, Self
 
 import attrs
 import h5py
@@ -9,6 +9,9 @@ import numpy as np
 import sleap_io as sio
 import torch
 from numpy.typing import ArrayLike
+
+if TYPE_CHECKING:
+    from dreem.io import Frame
 
 logger = logging.getLogger("dreem.io")
 
@@ -98,7 +101,7 @@ class Instance:
     )
     _pose: dict[str, ArrayLike] = attrs.field(alias="pose", factory=dict)
     _device: str | torch.device | None = attrs.field(alias="device", default=None)
-    _frame: "Frame" = None
+    _frame: Frame | None = None
 
     def __attrs_post_init__(self) -> None:
         """Handle dimensionality and more intricate default initializations post-init."""
@@ -272,7 +275,7 @@ class Instance:
             The h5 group representing this instance.
         """
         if label is None:
-            if pred_track_id != -1:
+            if self.pred_track_id != -1:
                 label = f"instance_{self.pred_track_id.item()}"
             else:
                 label = f"instance_{self.gt_track_id.item()}"
@@ -597,7 +600,7 @@ class Instance:
         self._embeddings[emb_type] = embedding
 
     @property
-    def frame(self) -> "Frame":
+    def frame(self) -> Frame:
         """Get the frame the instance belongs to.
 
         Returns:
@@ -606,7 +609,7 @@ class Instance:
         return self._frame
 
     @frame.setter
-    def frame(self, frame: "Frame") -> None:
+    def frame(self, frame: Frame) -> None:
         """Set the back reference to the `Frame` that this `Instance` belongs to.
 
         This field is set when instances are added to `Frame` object.

--- a/dreem/io/track.py
+++ b/dreem/io/track.py
@@ -1,6 +1,7 @@
 """Module containing data structures for storing instances of the same Track."""
 
 from __future__ import annotations
+
 import attrs
 
 

--- a/dreem/io/track.py
+++ b/dreem/io/track.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import attrs
+
+if TYPE_CHECKING:
+    from dreem.io import Frame, Instance
 
 
 @attrs.define(eq=False)
@@ -15,7 +20,7 @@ class Track:
     """
 
     _id: int = attrs.field(alias="id")
-    _instances: list["Instance"] = attrs.field(alias="instances", factory=list)
+    _instances: list[Instance] = attrs.field(alias="instances", factory=list)
 
     def __repr__(self) -> str:
         """Get the string representation of the track.
@@ -44,7 +49,7 @@ class Track:
         self._id = track_id
 
     @property
-    def instances(self) -> list["Instances"]:
+    def instances(self) -> list[Instance]:
         """Get the instances belonging to this track.
 
         Returns:
@@ -62,7 +67,7 @@ class Track:
         self._instances = instances
 
     @property
-    def frames(self) -> set["Frame"]:
+    def frames(self) -> set[Frame]:
         """Get the frames where this track appears.
 
         Returns:
@@ -78,7 +83,7 @@ class Track:
         """
         return len(self.instances)
 
-    def __getitem__(self, ind: int | list[int]) -> "Instance" | list["Instance"]:
+    def __getitem__(self, ind: int | list[int]) -> Instance | list[Instance]:
         """Get an instance from the track.
 
         Args:

--- a/dreem/io/track.py
+++ b/dreem/io/track.py
@@ -20,7 +20,7 @@ class Track:
     """
 
     _id: int = attrs.field(alias="id")
-    _instances: list[Instance] = attrs.field(alias="instances", factory=list)
+    _instances: list["Instance"] = attrs.field(alias="instances", factory=list)
 
     def __repr__(self) -> str:
         """Get the string representation of the track.
@@ -49,7 +49,7 @@ class Track:
         self._id = track_id
 
     @property
-    def instances(self) -> list[Instance]:
+    def instances(self) -> list["Instance"]:
         """Get the instances belonging to this track.
 
         Returns:
@@ -83,7 +83,7 @@ class Track:
         """
         return len(self.instances)
 
-    def __getitem__(self, ind: int | list[int]) -> Instance | list[Instance]:
+    def __getitem__(self, ind: int | list[int]) -> "Instance" | list["Instance"]:
         """Get an instance from the track.
 
         Args:

--- a/dreem/io/visualize.py
+++ b/dreem/io/visualize.py
@@ -1,17 +1,17 @@
 """Helper functions for visualizing tracking."""
 
-from scipy.interpolate import interp1d
-from copy import deepcopy
-from tqdm import tqdm
-from omegaconf import DictConfig
-
-import seaborn as sns
-import imageio
-import hydra
-import pandas as pd
-import numpy as np
-import cv2
 import logging
+from copy import deepcopy
+
+import cv2
+import hydra
+import imageio
+import numpy as np
+import pandas as pd
+import seaborn as sns
+from omegaconf import DictConfig
+from scipy.interpolate import interp1d
+from tqdm import tqdm
 
 logger = logging.getLogger("dreem.io")
 

--- a/dreem/io/visualize.py
+++ b/dreem/io/visualize.py
@@ -23,7 +23,7 @@ def fill_missing(data: np.ndarray, kind: str = "linear") -> np.ndarray:
 
     Args:
         data: the array for which to fill missing value
-        kind: How to interpolate missing values using `scipy.interpoloate.interp1d`
+        kind: How to interpolate missing values using `scipy.interpolate.interp1d`
 
     Returns:
         The array with missing values filled in

--- a/dreem/io/visualize.py
+++ b/dreem/io/visualize.py
@@ -88,7 +88,9 @@ def annotate_video(
         names: Whether or not to annotate with name
         centroids: The size of the centroid. If centroid size <= 0 or None then it is not added
         poses: Whether or not to annotate with poses
+        save_path: The path to save the annotated video.
         fps: The frame rate of the generated video
+        track_scores: Minimum track score threshold for displaying tracks
         alpha: The opacity of the annotations.
 
     Returns:

--- a/dreem/models/__init__.py
+++ b/dreem/models/__init__.py
@@ -13,3 +13,15 @@ from .visual_encoder import (
     create_visual_encoder,
     register_encoder,
 )
+
+__all__ = [
+    "Embedding",
+    "FourierPositionalEmbeddings",
+    "GlobalTrackingTransformer",
+    "GTRRunner",
+    "Transformer",
+    "DescriptorVisualEncoder",
+    "VisualEncoder",
+    "create_visual_encoder",
+    "register_encoder",
+]

--- a/dreem/models/__init__.py
+++ b/dreem/models/__init__.py
@@ -1,17 +1,15 @@
 """Model architectures and layers."""
 
 from .embedding import Embedding, FourierPositionalEmbeddings
+from .global_tracking_transformer import GlobalTrackingTransformer
+from .gtr_runner import GTRRunner
 
 # from .mlp import MLP
 # from .attention_head import ATTWeightHead
-
 from .transformer import Transformer
 from .visual_encoder import (
-    VisualEncoder,
     DescriptorVisualEncoder,
+    VisualEncoder,
     create_visual_encoder,
     register_encoder,
 )
-
-from .global_tracking_transformer import GlobalTrackingTransformer
-from .gtr_runner import GTRRunner

--- a/dreem/models/attention_head.py
+++ b/dreem/models/attention_head.py
@@ -1,6 +1,7 @@
 """Module containing different components of multi-head attention heads."""
 
 import torch
+
 from dreem.models.mlp import MLP
 
 # todo: add named tensors

--- a/dreem/models/attention_head.py
+++ b/dreem/models/attention_head.py
@@ -40,7 +40,8 @@ class ATTWeightHead(torch.nn.Module):
             key: Input tensor of shape (batch_size, num_window_instances, feature_dim).
 
         Returns:
-            Output tensor of shape (batch_size, num_frame_instances, num_window_instances).
+            Output tensor of shape
+            (batch_size, num_frame_instances, num_window_instances).
         """
         k = self.k_proj(key)
         q = self.q_proj(query)

--- a/dreem/models/embedding.py
+++ b/dreem/models/embedding.py
@@ -45,18 +45,25 @@ class Embedding(torch.nn.Module):
         """Initialize embeddings.
 
         Args:
-            emb_type: The type of embedding to compute. Must be one of `{"temp", "pos", "off"}`
+            emb_type: The type of embedding to compute.
+                Must be one of `{"temp", "pos", "off"}`
             mode: The mode or function used to map positions to vector embeddings.
                   Must be one of `{"fixed", "learned", "off"}`
             features: The embedding dimensions. Must match the dimension of the
                       input vectors for the transformer model.
             n_points: the number of points that will be embedded.
-            emb_num: the number of embeddings in the `self.lookup` table (Only used in learned embeddings).
-            over_boxes: Whether to compute the position embedding for each bbox coordinate (y1x1y2x2) or the centroid + bbox size (yxwh).
-            temperature: the temperature constant to be used when computing the sinusoidal position embedding
-            normalize: whether or not to normalize the positions (Only used in fixed embeddings).
-            scale: factor by which to scale the positions after normalizing (Only used in fixed embeddings).
-            mlp_cfg: A dictionary of mlp hyperparameters for projecting embedding to correct space.
+            emb_num: the number of embeddings in the `self.lookup` table
+                (Only used in learned embeddings).
+            over_boxes: Whether to compute the position embedding for each bbox
+                coordinate (y1x1y2x2) or the centroid + bbox size (yxwh).
+            temperature: the temperature constant to be used when computing
+                the sinusoidal position embedding
+            normalize: whether or not to normalize the positions
+                (Only used in fixed embeddings).
+            scale: factor by which to scale the positions after normalizing
+                (Only used in fixed embeddings).
+            mlp_cfg: A dictionary of mlp hyperparameters for projecting
+                embedding to correct space.
                     Example: {"hidden_dims": 256, "num_layers":3, "dropout": 0.3}
         """
         self._check_init_args(emb_type, mode)

--- a/dreem/models/embedding.py
+++ b/dreem/models/embedding.py
@@ -1,8 +1,10 @@
 """Module containing different position and temporal embeddings."""
 
-import math
-import torch
 import logging
+import math
+
+import torch
+
 from dreem.models.mlp import MLP
 
 logger = logging.getLogger("dreem.models")
@@ -175,7 +177,7 @@ class Embedding(torch.nn.Module):
     def _sine_box_embedding(self, boxes: torch.Tensor) -> torch.Tensor:
         """Compute sine positional embeddings for boxes using given parameters.
 
-         Args:
+        Args:
              boxes: the input boxes of shape N, n_anchors, 4 or B, N, n_anchors, 4
                     where the last dimension is the bbox coords in [y1, x1, y2, x2].
                     (Note currently `B=batch_size=1`).
@@ -405,9 +407,7 @@ class FourierPositionalEmbeddings(torch.nn.Module):
                 ),
             ),
             axis=-1,
-        ) / math.sqrt(
-            len(freq)
-        )  # (B,N,2*n_components)
+        ) / math.sqrt(len(freq))  # (B,N,2*n_components)
 
         if self.d_model % self.n_components != 0:
             raise ValueError(

--- a/dreem/models/global_tracking_transformer.py
+++ b/dreem/models/global_tracking_transformer.py
@@ -2,7 +2,8 @@
 
 import torch
 
-from dreem.models import Transformer, create_visual_encoder
+from dreem.models.transformer import Transformer
+from dreem.models.visual_encoder import create_visual_encoder
 
 # todo: do we want to handle params with configs already here?
 

--- a/dreem/models/global_tracking_transformer.py
+++ b/dreem/models/global_tracking_transformer.py
@@ -1,9 +1,14 @@
 """Module containing GTR model used for training."""
 
+from typing import TYPE_CHECKING
+
 import torch
 
 from dreem.models.transformer import Transformer
 from dreem.models.visual_encoder import create_visual_encoder
+
+if TYPE_CHECKING:
+    from dreem.io import AssociationMatrix, Instance
 
 # todo: do we want to handle params with configs already here?
 
@@ -79,8 +84,8 @@ class GlobalTrackingTransformer(torch.nn.Module):
         )
 
     def forward(
-        self, ref_instances: list["Instance"], query_instances: list["Instance"] = None
-    ) -> list["AssociationMatrix"]:
+        self, ref_instances: list[Instance], query_instances: list[Instance] = None
+    ) -> list[AssociationMatrix]:
         """Execute forward pass of GTR Model to get asso matrix.
 
         Args:
@@ -101,7 +106,7 @@ class GlobalTrackingTransformer(torch.nn.Module):
         return asso_preds
 
     def extract_features(
-        self, instances: list["Instance"], force_recompute: bool = False
+        self, instances: list[Instance], force_recompute: bool = False
     ) -> None:
         """Extract features from instances using visual encoder backbone.
 

--- a/dreem/models/global_tracking_transformer.py
+++ b/dreem/models/global_tracking_transformer.py
@@ -33,7 +33,7 @@ class GlobalTrackingTransformer(torch.nn.Module):
             encoder_cfg: Dictionary of arguments to pass to the CNN constructor,
                 e.g: `cfg = {"model_name": "resnet18", "pretrained": False, "in_chans": 3}`
             d_model: The number of features in the encoder/decoder inputs.
-            nhead: The number of heads in the transfomer encoder/decoder.
+            nhead: The number of heads in the transformer encoder/decoder.
             num_encoder_layers: The number of encoder-layers in the encoder.
             num_decoder_layers: The number of decoder-layers in the decoder.
             dropout: Dropout value applied to the output of transformer layers.

--- a/dreem/models/global_tracking_transformer.py
+++ b/dreem/models/global_tracking_transformer.py
@@ -1,8 +1,8 @@
 """Module containing GTR model used for training."""
 
-from dreem.models import Transformer
-from dreem.models import create_visual_encoder
 import torch
+
+from dreem.models import Transformer, create_visual_encoder
 
 # todo: do we want to handle params with configs already here?
 

--- a/dreem/models/global_tracking_transformer.py
+++ b/dreem/models/global_tracking_transformer.py
@@ -84,8 +84,8 @@ class GlobalTrackingTransformer(torch.nn.Module):
         )
 
     def forward(
-        self, ref_instances: list[Instance], query_instances: list[Instance] = None
-    ) -> list[AssociationMatrix]:
+        self, ref_instances: list["Instance"], query_instances: list["Instance"] = None
+    ) -> list["AssociationMatrix"]:
         """Execute forward pass of GTR Model to get asso matrix.
 
         Args:
@@ -106,7 +106,7 @@ class GlobalTrackingTransformer(torch.nn.Module):
         return asso_preds
 
     def extract_features(
-        self, instances: list[Instance], force_recompute: bool = False
+        self, instances: list["Instance"], force_recompute: bool = False
     ) -> None:
         """Extract features from instances using visual encoder backbone.
 

--- a/dreem/models/gtr_runner.py
+++ b/dreem/models/gtr_runner.py
@@ -170,9 +170,7 @@ class GTRRunner(LightningModule):
 
         return result
 
-    def predict_step(
-        self, batch: list[list[Frame]], batch_idx: int
-    ) -> list[Frame]:
+    def predict_step(self, batch: list[list[Frame]], batch_idx: int) -> list[Frame]:
         """Run inference for model.
 
         Computes association + assignment.
@@ -188,9 +186,7 @@ class GTRRunner(LightningModule):
         frames_pred = self.tracker(self.model, batch[0])
         return frames_pred
 
-    def _shared_eval_step(
-        self, frames: list[Frame], mode: str
-    ) -> dict[str, float]:
+    def _shared_eval_step(self, frames: list[Frame], mode: str) -> dict[str, float]:
         """Run evaluation used by train, test, and val steps.
 
         Args:

--- a/dreem/models/gtr_runner.py
+++ b/dreem/models/gtr_runner.py
@@ -101,9 +101,9 @@ class GTRRunner(LightningModule):
 
     def forward(
         self,
-        ref_instances: list[Instance],
-        query_instances: list[Instance] | None = None,
-    ) -> list[AssociationMatrix]:
+        ref_instances: list["Instance"],
+        query_instances: list["Instance"] | None = None,
+    ) -> list["AssociationMatrix"]:
         """Execute forward pass of the lightning module.
 
         Args:
@@ -117,7 +117,7 @@ class GTRRunner(LightningModule):
         return asso_preds
 
     def training_step(
-        self, train_batch: list[list[Frame]], batch_idx: int
+        self, train_batch: list[list["Frame"]], batch_idx: int
     ) -> dict[str, float]:
         """Execute single training step for model.
 
@@ -135,7 +135,7 @@ class GTRRunner(LightningModule):
         return result
 
     def validation_step(
-        self, val_batch: list[list[Frame]], batch_idx: int
+        self, val_batch: list[list["Frame"]], batch_idx: int
     ) -> dict[str, float]:
         """Execute single val step for model.
 
@@ -153,7 +153,7 @@ class GTRRunner(LightningModule):
         return result
 
     def test_step(
-        self, test_batch: list[list[Frame]], batch_idx: int
+        self, test_batch: list[list["Frame"]], batch_idx: int
     ) -> dict[str, float]:
         """Execute single test step for model.
 
@@ -170,7 +170,7 @@ class GTRRunner(LightningModule):
 
         return result
 
-    def predict_step(self, batch: list[list[Frame]], batch_idx: int) -> list[Frame]:
+    def predict_step(self, batch: list[list["Frame"]], batch_idx: int) -> list["Frame"]:
         """Run inference for model.
 
         Computes association + assignment.
@@ -186,7 +186,7 @@ class GTRRunner(LightningModule):
         frames_pred = self.tracker(self.model, batch[0])
         return frames_pred
 
-    def _shared_eval_step(self, frames: list[Frame], mode: str) -> dict[str, float]:
+    def _shared_eval_step(self, frames: list["Frame"], mode: str) -> dict[str, float]:
         """Run evaluation used by train, test, and val steps.
 
         Args:

--- a/dreem/models/gtr_runner.py
+++ b/dreem/models/gtr_runner.py
@@ -1,23 +1,23 @@
 """Module containing training, validation and inference logic."""
 
-import torch
 import gc
 import logging
-import pandas as pd
-import h5py
 import os
-from dreem.inference import Tracker, BatchTracker
-from dreem.inference import metrics
-from dreem.models import GlobalTrackingTransformer
-from dreem.datasets import CellTrackingDataset
-from dreem.training.losses import AssoLoss
-from dreem.models.model_utils import init_optimizer, init_scheduler
-from pytorch_lightning import LightningModule
 from datetime import datetime
 from pathlib import Path
-import sleap_io as sio
+
+import h5py
 import numpy as np
+import sleap_io as sio
 import tifffile
+import torch
+from pytorch_lightning import LightningModule
+
+from dreem.datasets import CellTrackingDataset
+from dreem.inference import BatchTracker, Tracker, metrics
+from dreem.models import GlobalTrackingTransformer
+from dreem.models.model_utils import init_optimizer, init_scheduler
+from dreem.training.losses import AssoLoss
 
 logger = logging.getLogger("dreem.models")
 if not logger.handlers:

--- a/dreem/models/gtr_runner.py
+++ b/dreem/models/gtr_runner.py
@@ -78,9 +78,11 @@ class GTRRunner(LightningModule):
         self.loss = AssoLoss(**self.loss_cfg)
         if self.tracker_cfg.get("tracker_type", "standard") == "batch":
             from dreem.inference.batch_tracker import BatchTracker
+
             self.tracker = BatchTracker(**self.tracker_cfg)
         else:
             from dreem.inference.tracker import Tracker
+
             self.tracker = Tracker(**self.tracker_cfg)
         self.optimizer_cfg = optimizer_cfg
         self.scheduler_cfg = scheduler_cfg

--- a/dreem/models/gtr_runner.py
+++ b/dreem/models/gtr_runner.py
@@ -202,7 +202,7 @@ class GTRRunner(LightningModule):
             if len(instances) == 0:
                 return None
 
-            eval_metrics = self.metrics[mode]
+            # eval_metrics = self.metrics[mode]  # Currently unused but available for future metric computation
 
             logits = self(instances)
             logits = [asso.matrix for asso in logits]
@@ -382,7 +382,7 @@ class GTRRunner(LightningModule):
             for frame in preds:
                 frame_masks = []
                 for instance in frame.instances:
-                    centroid = instance.centroid["centroid"]
+                    # centroid = instance.centroid["centroid"]  # Currently unused but available if needed
                     mask = instance.mask.cpu().numpy()
                     track_id = instance.pred_track_id.cpu().numpy().item()
                     mask = mask.astype(np.uint8)

--- a/dreem/models/gtr_runner.py
+++ b/dreem/models/gtr_runner.py
@@ -5,6 +5,7 @@ import logging
 import os
 from datetime import datetime
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import h5py
 import numpy as np
@@ -18,6 +19,9 @@ from dreem.inference import metrics
 from dreem.models.global_tracking_transformer import GlobalTrackingTransformer
 from dreem.models.model_utils import init_optimizer, init_scheduler
 from dreem.training.losses import AssoLoss
+
+if TYPE_CHECKING:
+    from dreem.io import AssociationMatrix, Frame, Instance
 
 logger = logging.getLogger("dreem.models")
 if not logger.handlers:
@@ -97,9 +101,9 @@ class GTRRunner(LightningModule):
 
     def forward(
         self,
-        ref_instances: list["dreem.io.Instance"],
-        query_instances: list["dreem.io.Instance"] | None = None,
-    ) -> list["AssociationMatrix"]:
+        ref_instances: list[Instance],
+        query_instances: list[Instance] | None = None,
+    ) -> list[AssociationMatrix]:
         """Execute forward pass of the lightning module.
 
         Args:
@@ -113,7 +117,7 @@ class GTRRunner(LightningModule):
         return asso_preds
 
     def training_step(
-        self, train_batch: list[list["dreem.io.Frame"]], batch_idx: int
+        self, train_batch: list[list[Frame]], batch_idx: int
     ) -> dict[str, float]:
         """Execute single training step for model.
 
@@ -131,7 +135,7 @@ class GTRRunner(LightningModule):
         return result
 
     def validation_step(
-        self, val_batch: list[list["dreem.io.Frame"]], batch_idx: int
+        self, val_batch: list[list[Frame]], batch_idx: int
     ) -> dict[str, float]:
         """Execute single val step for model.
 
@@ -149,7 +153,7 @@ class GTRRunner(LightningModule):
         return result
 
     def test_step(
-        self, test_batch: list[list["dreem.io.Frame"]], batch_idx: int
+        self, test_batch: list[list[Frame]], batch_idx: int
     ) -> dict[str, float]:
         """Execute single test step for model.
 
@@ -167,8 +171,8 @@ class GTRRunner(LightningModule):
         return result
 
     def predict_step(
-        self, batch: list[list["dreem.io.Frame"]], batch_idx: int
-    ) -> list["dreem.io.Frame"]:
+        self, batch: list[list[Frame]], batch_idx: int
+    ) -> list[Frame]:
         """Run inference for model.
 
         Computes association + assignment.
@@ -185,7 +189,7 @@ class GTRRunner(LightningModule):
         return frames_pred
 
     def _shared_eval_step(
-        self, frames: list["dreem.io.Frame"], mode: str
+        self, frames: list[Frame], mode: str
     ) -> dict[str, float]:
         """Run evaluation used by train, test, and val steps.
 

--- a/dreem/models/gtr_runner.py
+++ b/dreem/models/gtr_runner.py
@@ -14,8 +14,8 @@ import torch
 from pytorch_lightning import LightningModule
 
 from dreem.datasets import CellTrackingDataset
-from dreem.inference import BatchTracker, Tracker, metrics
-from dreem.models import GlobalTrackingTransformer
+from dreem.inference import metrics
+from dreem.models.global_tracking_transformer import GlobalTrackingTransformer
 from dreem.models.model_utils import init_optimizer, init_scheduler
 from dreem.training.losses import AssoLoss
 
@@ -77,8 +77,10 @@ class GTRRunner(LightningModule):
         self.model = GlobalTrackingTransformer(**self.model_cfg)
         self.loss = AssoLoss(**self.loss_cfg)
         if self.tracker_cfg.get("tracker_type", "standard") == "batch":
+            from dreem.inference.batch_tracker import BatchTracker
             self.tracker = BatchTracker(**self.tracker_cfg)
         else:
+            from dreem.inference.tracker import Tracker
             self.tracker = Tracker(**self.tracker_cfg)
         self.optimizer_cfg = optimizer_cfg
         self.scheduler_cfg = scheduler_cfg

--- a/dreem/models/model_utils.py
+++ b/dreem/models/model_utils.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
     from dreem.io import Instance
 
 
-def get_boxes(instances: list[Instance]) -> torch.Tensor:
+def get_boxes(instances: list["Instance"]) -> torch.Tensor:
     """Extract the bounding boxes from the input list of instances.
 
     Args:
@@ -33,8 +33,8 @@ def get_boxes(instances: list[Instance]) -> torch.Tensor:
 
 
 def get_times(
-    ref_instances: list[Instance],
-    query_instances: list[Instance] | None = None,
+    ref_instances: list["Instance"],
+    query_instances: list["Instance"] | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Extract the time indices of each instance relative to the window length.
 

--- a/dreem/models/model_utils.py
+++ b/dreem/models/model_utils.py
@@ -124,7 +124,7 @@ def init_optimizer(params: Iterable, config: dict) -> torch.optim.Optimizer:
             optimizer_class = getattr(torch.optim, optimizer.lower().capitalize())
         if optimizer_class is None:
             print(
-                f"Couldnt instantiate {optimizer} with capitalization, Final attempt with all caps"
+                f"Couldn't instantiate {optimizer} with capitalization, Final attempt with all caps"
             )
             optimizer_class = getattr(torch.optim, optimizer.upper(), None)
 
@@ -186,7 +186,7 @@ def init_scheduler(
             )
         if scheduler_class is None:
             print(
-                f"Couldnt instantiate {scheduler} with capitalization, Final attempt with all caps"
+                f"Couldn't instantiate {scheduler} with capitalization, Final attempt with all caps"
             )
             scheduler_class = getattr(torch.optim.lr_scheduler, scheduler.upper(), None)
 

--- a/dreem/models/model_utils.py
+++ b/dreem/models/model_utils.py
@@ -1,12 +1,15 @@
 """Module containing model helper functions."""
 
-from typing import Iterable
+from typing import TYPE_CHECKING, Iterable
 
 import torch
 from pytorch_lightning import loggers
 
+if TYPE_CHECKING:
+    from dreem.io import Instance
 
-def get_boxes(instances: list["dreem.io.Instance"]) -> torch.Tensor:
+
+def get_boxes(instances: list[Instance]) -> torch.Tensor:
     """Extract the bounding boxes from the input list of instances.
 
     Args:
@@ -30,8 +33,8 @@ def get_boxes(instances: list["dreem.io.Instance"]) -> torch.Tensor:
 
 
 def get_times(
-    ref_instances: list["dreem.io.Instance"],
-    query_instances: list["dreem.io.Instance"] | None = None,
+    ref_instances: list[Instance],
+    query_instances: list[Instance] | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Extract the time indices of each instance relative to the window length.
 

--- a/dreem/models/model_utils.py
+++ b/dreem/models/model_utils.py
@@ -1,8 +1,9 @@
 """Module containing model helper functions."""
 
 from typing import Iterable
-from pytorch_lightning import loggers
+
 import torch
+from pytorch_lightning import loggers
 
 
 def get_boxes(instances: list["dreem.io.Instance"]) -> torch.Tensor:

--- a/dreem/models/transformer.py
+++ b/dreem/models/transformer.py
@@ -50,7 +50,7 @@ class Transformer(torch.nn.Module):
 
         Args:
             d_model: The number of features in the encoder/decoder inputs.
-            nhead: The number of heads in the transfomer encoder/decoder.
+            nhead: The number of heads in the transformer encoder/decoder.
             num_encoder_layers: The number of encoder-layers in the encoder.
             num_decoder_layers: The number of decoder-layers in the decoder.
             dropout: Dropout value applied to the output of transformer layers.
@@ -332,7 +332,7 @@ def apply_fourier_embeddings(
         times: The times index tensor of shape (n_query,).
         d_model: Model dimension.
         fourier_embeddings: The Fourier positional embeddings object.
-        proj: Linear projection layer that projects concantenated feature vector to model dimension.
+        proj: Linear projection layer that projects concatenated feature vector to model dimension.
         norm: The normalization layer.
 
     Returns:

--- a/dreem/models/transformer.py
+++ b/dreem/models/transformer.py
@@ -186,7 +186,7 @@ class Transformer(torch.nn.Module):
         ref_boxes = torch.nan_to_num(ref_boxes, -1.0)
         ref_times, query_times = get_times(ref_instances, query_instances)
 
-        window_length = len(ref_times.unique())
+        # window_length = len(ref_times.unique())  # Currently unused but may be useful for debugging
 
         ref_temp_emb = self.temp_emb(ref_times)
 

--- a/dreem/models/transformer.py
+++ b/dreem/models/transformer.py
@@ -18,7 +18,7 @@ import torch.nn.functional as F
 from torch import nn
 
 from dreem.io import AssociationMatrix
-from dreem.models import Embedding, FourierPositionalEmbeddings
+from dreem.models.embedding import Embedding, FourierPositionalEmbeddings
 from dreem.models.attention_head import ATTWeightHead
 from dreem.models.model_utils import get_boxes, get_times
 

--- a/dreem/models/transformer.py
+++ b/dreem/models/transformer.py
@@ -11,14 +11,16 @@ Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
     * added fixed embeddings over boxes
 """
 
-from dreem.io import AssociationMatrix
-from dreem.models.attention_head import ATTWeightHead
-from dreem.models import Embedding, FourierPositionalEmbeddings
-from dreem.models.model_utils import get_boxes, get_times
-from torch import nn
 import copy
+
 import torch
 import torch.nn.functional as F
+from torch import nn
+
+from dreem.io import AssociationMatrix
+from dreem.models import Embedding, FourierPositionalEmbeddings
+from dreem.models.attention_head import ATTWeightHead
+from dreem.models.model_utils import get_boxes, get_times
 
 # todo: add named tensors
 # todo: add flash attention
@@ -499,9 +501,7 @@ class TransformerDecoderLayer(nn.Module):
             query=decoder_queries,  # (n_query, batch_size, embed_dim)
             key=encoder_features,  # (total_instances, batch_size, embed_dim)
             value=encoder_features,  # (total_instances, batch_size, embed_dim)
-        )[
-            0
-        ]  # (n_query, batch_size, embed_dim)
+        )[0]  # (n_query, batch_size, embed_dim)
 
         decoder_queries = decoder_queries + self.dropout2(
             x_attn_features

--- a/dreem/models/transformer.py
+++ b/dreem/models/transformer.py
@@ -18,8 +18,8 @@ import torch.nn.functional as F
 from torch import nn
 
 from dreem.io import AssociationMatrix
-from dreem.models.embedding import Embedding, FourierPositionalEmbeddings
 from dreem.models.attention_head import ATTWeightHead
+from dreem.models.embedding import Embedding, FourierPositionalEmbeddings
 from dreem.models.model_utils import get_boxes, get_times
 
 # todo: add named tensors

--- a/dreem/models/transformer.py
+++ b/dreem/models/transformer.py
@@ -17,7 +17,7 @@ import torch
 import torch.nn.functional as F
 from torch import nn
 
-from dreem.io import AssociationMatrix
+from dreem.io import AssociationMatrix, Instance
 from dreem.models.attention_head import ATTWeightHead
 from dreem.models.embedding import Embedding, FourierPositionalEmbeddings
 from dreem.models.model_utils import get_boxes, get_times
@@ -158,8 +158,8 @@ class Transformer(torch.nn.Module):
 
     def forward(
         self,
-        ref_instances: list["dreem.io.Instance"],
-        query_instances: list["dreem.io.Instance"] | None = None,
+        ref_instances: list[Instance],
+        query_instances: list[Instance] | None = None,
     ) -> list[AssociationMatrix]:
         """Execute a forward pass through the transformer and attention head.
 

--- a/dreem/models/visual_encoder.py
+++ b/dreem/models/visual_encoder.py
@@ -1,13 +1,13 @@
 """Module for different visual feature extractors."""
 
-from typing import Any, Type, Dict
-import torch
-import torchvision
-import timm
-import torch.nn.functional as F
-import skimage.measure as measure
-from skimage.feature import local_binary_pattern
+from typing import Any, Dict, Type
+
 import numpy as np
+import skimage.measure as measure
+import timm
+import torch
+import torch.nn.functional as F
+import torchvision
 
 # import timm
 

--- a/dreem/models/visual_encoder.py
+++ b/dreem/models/visual_encoder.py
@@ -172,6 +172,7 @@ class DescriptorVisualEncoder(torch.nn.Module):
 
         Args:
             use_hu_moments: Whether to use Hu moments.
+            **kwargs: Additional keyword arguments (unused but accepted for compatibility).
         """
         super().__init__()
         self.use_hu_moments = use_hu_moments

--- a/dreem/training/configs/README.md
+++ b/dreem/training/configs/README.md
@@ -553,7 +553,7 @@ dataset:
         clip_length: 32
         anchors: ["node1", "node2", ..."node_n"]
         handle_missing: "drop"
-        ... # we don't include augmentations bc usually you shouldnt use augmentations during val/test
+        ... # we don't include augmentations bc usually you shouldn't use augmentations during val/test
     test_dataset:
         slp_files: ["/path/to/test/labels1.slp", "/path/to/test/labels2.slp", ..., "/path/to/test/labelsN.slp"]
         video_files: ["/path/to/test/video1.mp4", "/path/to/test/video2.mp4", ..., "/path/to/test/videoN.mp4"]
@@ -563,7 +563,7 @@ dataset:
         clip_length: 32
         anchors: ["node1", "node2", ..."node_n"]
         handle_missing: "drop"
-        ... # we don't include augmentations bc usually you shouldnt use augmentations during val/test
+        ... # we don't include augmentations bc usually you shouldn't use augmentations during val/test
 ...
 ```
 #### [`MicroscopyDataset`](../../datasets/microscopy_dataset.py)
@@ -594,7 +594,7 @@ dataset:
         crop_size: 128 
         chunk: True
         clip_length: 32
-        ... # we don't include augmentations bc usually you shouldnt use augmentations during val/test
+        ... # we don't include augmentations bc usually you shouldn't use augmentations during val/test
     test_dataset:
         tracks: ["/path/to/test/labels1.csv", "/path/to/test/labels2.csv", ..., "/path/to/test/labelsN.csv"]
         videos: ["/path/to/test/video1.tiff", "/path/to/test/video2.tiff", ..., "/path/to/test/videoN.tiff"]
@@ -603,7 +603,7 @@ dataset:
         crop_size: 128 
         chunk: True
         clip_length: 32
-        ... # we don't include augmentations bc usually you shouldnt use augmentations during val/test
+        ... # we don't include augmentations bc usually you shouldn't use augmentations during val/test
 ```
 ## [`dataloader`](base.yaml#L92-101)
 

--- a/dreem/training/losses.py
+++ b/dreem/training/losses.py
@@ -1,10 +1,11 @@
 """Module containing different loss functions to be optimized."""
 
-from dreem.models.model_utils import get_boxes, get_times
-from torch import nn
 import torch
 import torch.nn.functional as F
 import torchvision
+from torch import nn
+
+from dreem.models.model_utils import get_boxes, get_times
 
 # todo: use named tensors
 # todo: clean up names, comments

--- a/dreem/training/losses.py
+++ b/dreem/training/losses.py
@@ -39,7 +39,7 @@ class AssoLoss(nn.Module):
         self.asso_weight = asso_weight
 
     def forward(
-        self, asso_preds: list[torch.Tensor], frames: list[Frame]
+        self, asso_preds: list[torch.Tensor], frames: list["Frame"]
     ) -> torch.Tensor:
         """Calculate association loss.
 

--- a/dreem/training/losses.py
+++ b/dreem/training/losses.py
@@ -1,11 +1,16 @@
 """Module containing different loss functions to be optimized."""
 
+from typing import TYPE_CHECKING
+
 import torch
 import torch.nn.functional as F
 import torchvision
 from torch import nn
 
 from dreem.models.model_utils import get_boxes, get_times
+
+if TYPE_CHECKING:
+    from dreem.io import Frame
 
 # todo: use named tensors
 # todo: clean up names, comments
@@ -34,7 +39,7 @@ class AssoLoss(nn.Module):
         self.asso_weight = asso_weight
 
     def forward(
-        self, asso_preds: list[torch.Tensor], frames: list["Frame"]
+        self, asso_preds: list[torch.Tensor], frames: list[Frame]
     ) -> torch.Tensor:
         """Calculate association loss.
 

--- a/dreem/training/train.py
+++ b/dreem/training/train.py
@@ -3,19 +3,20 @@
 Used for training a single model or deploying a batch train job on RUNAI CLI
 """
 
-from dreem.io import Config
-from dreem.datasets import TrackingDataset
-from dreem.datasets.data_utils import view_training_batch
-from multiprocessing import cpu_count
-from omegaconf import DictConfig
-
+import logging
 import os
+from multiprocessing import cpu_count
+
 import hydra
 import pandas as pd
 import pytorch_lightning as pl
 import torch
 import torch.multiprocessing
-import logging
+from omegaconf import DictConfig
+
+from dreem.datasets import TrackingDataset
+from dreem.datasets.data_utils import view_training_batch
+from dreem.io import Config
 
 logger = logging.getLogger("training")
 

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ channels:
   - defaults
 
 dependencies:
-  - python=3.11
+  - python=3.12
   - pytorch-cuda=12.1
   - conda-forge::opencv <4.9.0
   - cudnn

--- a/environment_cpu.yml
+++ b/environment_cpu.yml
@@ -7,7 +7,7 @@ channels:
   - defaults
 
 dependencies:
-  - python=3.11
+  - python=3.12
   - conda-forge::opencv <4.9.0
   - pytorch
   - cpuonly

--- a/environment_osx-arm64.yml
+++ b/environment_osx-arm64.yml
@@ -6,7 +6,7 @@ channels:
   - defaults
 
 dependencies:
-  - python=3.11
+  - python=3.12
   - pytorch
   - torchvision
   - lightning

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -146,7 +146,7 @@ extra_css:
   - css/mkdocstrings.css
 
 copyright: >
-  Copyright &copy; 2024 - 2024 Talmo Lab –
+  Copyright &copy; 2024 - 2025 Talmo Lab –
   <a href="#__consent">Change cookie settings</a>
 nav:
   - Overview: index.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "dreem"
+name = "dreem-tracker"
 authors = [
     {name = "Arlo Sheridan", email = "asheridan@salk.edu"},
     {name = "Aaditya Prasad", email = "aprasad@salk.edu"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,9 @@ dev = [
     "mkdocs-jupyter",
     "mkdocstrings[python]>=0.18",
     "mkdocs-gen-files",
-    "mkdocs-literate-nav"
+    "mkdocs-literate-nav",
+    "mike",
+    "mkdocs-section-index"
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,5 +86,5 @@ select = [
 convention = "google"
 
 [tool.codespell]
-skip = "*.po,*.ts,./docs/_build,./docs/venv,./site,*.ipynb,.git,__pycache__"
+skip = "*.po,*.ts,./docs/_build,./docs/venv,./site,*.ipynb,.git,__pycache__,*.csv"
 ignore-words-list = "te,sleeap,thinc,mot,MOT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,8 +39,7 @@ readme = {file = ["README.md"]}
 dev = [
     "pytest",
     "pytest-cov",
-    "black",
-    "pydocstyle",
+    "ruff",
     "toml",
     "twine",
     "build",
@@ -69,3 +68,18 @@ line-length = 88
 [pydocstyle]
 convention = "google"
 match-dir = "sleap_roots"
+
+[tool.ruff]
+line-length = 88
+
+[tool.ruff.lint]
+select = [
+    "E",    # pycodestyle errors
+    "W",    # pycodestyle warnings
+    "F",    # pyflakes
+    "D",    # pydocstyle
+    "I",    # isort
+]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dev = [
     "pytest",
     "pytest-cov",
     "ruff",
+    "codespell",
     "toml",
     "twine",
     "build",
@@ -83,3 +84,7 @@ select = [
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"
+
+[tool.codespell]
+skip = "*.po,*.ts,./docs/_build,./docs/venv,./site,*.ipynb,.git,__pycache__"
+ignore-words-list = "te,sleeap,thinc,mot,MOT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,14 +12,11 @@ authors = [
     {name = "Talmo Pereira", email = "talmo@salk.edu"},
 ]
 description = "Global Tracking Transformers for biological multi-object tracking."
-requires-python = ">=3.8"
+requires-python = ">=3.12"
 keywords = ["gtr", "mot"]
 license = {text = "BSD-3-Clause"}
 classifiers = [
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
     "torch >= 2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ select = [
     "D",    # pydocstyle
     "I",    # isort
 ]
+ignore = ["E501"]  # Line too long - let formatter handle this
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/tests/fixtures/configs.py
+++ b/tests/fixtures/configs.py
@@ -1,6 +1,7 @@
 """Test config paths."""
 
 import os
+
 import pytest
 
 

--- a/tests/fixtures/datasets.py
+++ b/tests/fixtures/datasets.py
@@ -1,9 +1,10 @@
 """Fixtures for testing dreem."""
 
-import pytest
-from pathlib import Path
 import glob
 import os
+from pathlib import Path
+
+import pytest
 
 
 @pytest.fixture

--- a/tests/fixtures/torch.py
+++ b/tests/fixtures/torch.py
@@ -1,5 +1,4 @@
-"""
-Commenting this file out for now.
+"""Commenting this file out for now.
 
 For some reason it screws up `test_training` by causing a device error
 """

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,5 @@
 """Tests for `config.py`"""
 
-
 import torch
 from omegaconf import OmegaConf, open_dict
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,11 +1,11 @@
 """Tests for `config.py`"""
 
-from omegaconf import OmegaConf, open_dict
-from copy import deepcopy
-from dreem.io import Config
-from dreem.models import GlobalTrackingTransformer, GTRRunner
 
 import torch
+from omegaconf import OmegaConf, open_dict
+
+from dreem.io import Config
+from dreem.models import GlobalTrackingTransformer, GTRRunner
 
 
 def test_init(base_config, params_config):

--- a/tests/test_data_model.py
+++ b/tests/test_data_model.py
@@ -1,15 +1,15 @@
 """Tests for Instance, Frame, and AssociationMatrix Objects"""
 
-from dreem.io import Frame, Instance, AssociationMatrix, Track
-import torch
-import pytest
 import numpy as np
 import pandas as pd
+import pytest
+import torch
+
+from dreem.io import AssociationMatrix, Frame, Instance, Track
 
 
 def test_instance():
     """Test Instance object logic."""
-
     gt_track_id = 0
     pred_track_id = 0
     bbox = torch.randn((1, 1, 4))
@@ -130,7 +130,6 @@ def test_frame():
 
 
 def test_association_matrix():
-
     n_traj = 2
     total_instances = 32
     n_query = 2
@@ -194,7 +193,6 @@ def test_association_matrix():
 
 
 def test_track():
-
     instances = [Instance(gt_track_id=0, pred_track_id=0) for i in range(32)]
 
     track = Track(0, instances=instances)

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,17 +1,17 @@
 """Test dataset logic."""
 
-from dreem.datasets import (
-    BaseDataset,
-    MicroscopyDataset,
-    SleapDataset,
-    CellTrackingDataset,
-    TrackingDataset,
-)
-from dreem.datasets.data_utils import get_max_padding, NodeDropout
-from dreem.models.model_utils import get_device
-from torch.utils.data import DataLoader
 import pytest
 import torch
+from torch.utils.data import DataLoader
+
+from dreem.datasets import (
+    BaseDataset,
+    CellTrackingDataset,
+    MicroscopyDataset,
+    SleapDataset,
+    TrackingDataset,
+)
+from dreem.datasets.data_utils import NodeDropout, get_max_padding
 
 
 def test_base_dataset():
@@ -268,7 +268,6 @@ def test_icy_dataset(ten_icy_particles):
     Args:
         ten_icy_particles: icy fixture used for testing
     """
-
     clip_length = 8
 
     train_ds = MicroscopyDataset(
@@ -318,7 +317,6 @@ def test_isbi_dataset(isbi_microtubules, isbi_receptors):
         isbi_microtubules: isbi microtubules fixture used for testing
         isbi_receptors: isbi receptors fixture used for testing
     """
-
     clip_length = 8
 
     for ds in [isbi_microtubules, isbi_receptors]:
@@ -346,7 +344,6 @@ def test_cell_tracking_dataset(cell_tracking):
     Args:
         cell_tracking: HL60 nuclei fixture used for testing
     """
-
     clip_length = 8
     raw_img_list, gt_list, ctc_track_meta, data_dir = cell_tracking
     train_ds = CellTrackingDataset(
@@ -510,7 +507,6 @@ def test_augmentations(two_flies, ten_icy_particles):
         two_flies: flies fixture used for testing
         ten_icy_particles: icy fixture used for testing
     """
-
     no_augs_ds = SleapDataset(
         slp_files=[two_flies[0]],
         video_files=[two_flies[1]],
@@ -554,16 +550,15 @@ def test_augmentations(two_flies, ten_icy_particles):
 
     for p in [0, 1]:
         for n in [0, 1, len(nodes)]:
-
             node_dropout = NodeDropout(p=p, n=n)
             dropped_nodes = node_dropout(nodes)
 
             if p == 0:
                 assert len(dropped_nodes) == 0
             else:
-                assert (
-                    len(dropped_nodes) == n
-                ), f"p={node_dropout.p}, n={node_dropout.n},n_dropped={len(dropped_nodes)}"
+                assert len(dropped_nodes) == n, (
+                    f"p={node_dropout.p}, n={node_dropout.n},n_dropped={len(dropped_nodes)}"
+                )
 
     no_augs_ds = MicroscopyDataset(
         videos=[ten_icy_particles[0]],

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -469,7 +469,7 @@ def test_tracking_dataset(two_flies):
         and tracking_ds.test_dataloader().batch_size == 2
     )
 
-    # test using overrided dls over defaults
+    # test using overridden dls over defaults
     tracking_ds = TrackingDataset(
         train_ds=train_sleap_ds,
         train_dl=train_sleap_dl,
@@ -484,7 +484,7 @@ def test_tracking_dataset(two_flies):
         and tracking_ds.val_dataloader().batch_size == 2
         and tracking_ds.test_dataloader().batch_size == 2
     )
-    # test using overrided dls over defaults with combinations
+    # test using overridden dls over defaults with combinations
     tracking_ds = TrackingDataset(
         train_ds=train_sleap_ds,
         val_ds=val_sleap_ds,

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1,16 +1,17 @@
 """Test inference logic."""
 
-import torch
-import pytest
-import numpy as np
-from pytorch_lightning import Trainer
-from omegaconf import OmegaConf, DictConfig
-from dreem.io import Frame, Instance, Config
-from dreem.models import GTRRunner, GlobalTrackingTransformer
-from dreem.inference import Tracker, post_processing, metrics, BatchTracker
-from dreem.inference.track_queue import TrackQueue
-from dreem.inference.track import run
 import os
+
+import numpy as np
+import torch
+from omegaconf import OmegaConf
+from pytorch_lightning import Trainer
+
+from dreem.inference import Tracker, metrics, post_processing
+from dreem.inference.track import run
+from dreem.inference.track_queue import TrackQueue
+from dreem.io import Config, Frame, Instance
+from dreem.models import GlobalTrackingTransformer, GTRRunner
 
 
 def test_track_queue():
@@ -265,7 +266,6 @@ def get_ckpt(ckpt_path: str):
     """Save GTR Runner to checkpoint file."""
 
     class DummyDataset(torch.utils.data.Dataset):
-
         def __len__(self):
             return 0
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,18 +2,19 @@
 
 import pytest
 import torch
+
 from dreem.io import Frame, Instance
-from dreem.models.mlp import MLP
-from dreem.models.attention_head import ATTWeightHead
 from dreem.models import (
     Embedding,
-    VisualEncoder,
-    Transformer,
     GlobalTrackingTransformer,
+    Transformer,
+    VisualEncoder,
 )
+from dreem.models.attention_head import ATTWeightHead
+from dreem.models.mlp import MLP
 from dreem.models.transformer import (
-    TransformerEncoderLayer,
     TransformerDecoderLayer,
+    TransformerEncoderLayer,
 )
 
 
@@ -130,7 +131,6 @@ def test_encoder_torch():
 
 def test_embedding_validity():
     """Test embedding usage."""
-
     # this would throw assertion since embedding should be "pos"
     with pytest.raises(Exception):
         _ = Embedding(emb_type="position", mode="learned", features=128)
@@ -169,7 +169,6 @@ def test_embedding_validity():
 
 def test_embedding_basic():
     """Test embedding logic."""
-
     frames = 32
     objects = 10
     d_model = 256
@@ -244,7 +243,6 @@ def test_embedding_basic():
 
 def test_embedding_kwargs():
     """Test embedding config logic."""
-
     frames = 32
     objects = 10
 

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -1,12 +1,14 @@
 """Test training logic."""
 
 import os
+
 import pytest
 import torch
-from dreem.io import Frame, Instance, Config
-from dreem.training.losses import AssoLoss
+from omegaconf import OmegaConf
+
+from dreem.io import Config, Frame, Instance
 from dreem.models import GTRRunner
-from omegaconf import OmegaConf, DictConfig
+from dreem.training.losses import AssoLoss
 from dreem.training.train import run
 
 # TODO: add named tensor tests


### PR DESCRIPTION
## Summary
This PR includes general clean-up and DevOps enhancements to improve code quality, modernize the tooling, and streamline the development workflow.

## Changes Made

### 1. **Dependencies & Tooling**
- ✅ Added missing mkdocs dependencies (`mike` and `mkdocs-section-index`) to dev extras
- ✅ Replaced `black` and `pydocstyle` with `ruff` for faster, unified linting and formatting
- ✅ Added `codespell` for automated spell checking
- ✅ Updated Python version to 3.12 across all configs (conda environments, pyproject.toml, CI)

### 2. **CI/CD Workflows**
- ✅ Added automated docs deployment workflow (`.github/workflows/docs.yml`)
  - Builds and deploys versioned docs using `mike`
  - Deploys to `latest` on releases, `dev` on pushes
- ✅ Added PyPI build workflow (`.github/workflows/build.yml`)
  - Uses `uv` for fast package building
  - Configured for PyPI trusted publisher (OIDC authentication)
- ✅ Added spell checking workflow (`.github/workflows/codespell.yml`)
- ✅ Updated CI workflow to use `ruff` instead of `black`/`pydocstyle`

### 3. **Code Quality Improvements**
- ✅ Applied `ruff` formatting to 12 files (consistent 88-char line length)
- ✅ Fixed 79 linting issues automatically with `ruff`
- ✅ Fixed ~35 spelling errors throughout the codebase
- ✅ Fixed circular imports introduced by import sorting
- ✅ Added CLAUDE.md for AI-assisted development guidance

### 4. **Project Configuration**
- ✅ Updated package name to `dreem-tracker` for PyPI (since `dreem` is taken)
- ✅ Updated copyright year to 2025 in mkdocs footer
- ✅ Added `.serena/` to .gitignore for MCP configuration
- ✅ Added `*.csv` to codespell skip list for data files
- ✅ Added ruff configuration to pyproject.toml

## Testing
- [x] Verified mkdocs dependencies work locally
- [x] Ran `ruff format` and `ruff check` locally
- [x] Ran `codespell` and fixed all legitimate typos
- [x] Tests pass locally (37/38 passing)
- [x] Docs workflow follows established patterns from other repos

## Notes
- The package will be published to PyPI as `dreem-tracker`
- Trusted publisher needs to be configured on PyPI with:
  - Owner: `talmolab`
  - Repository: `dreem`
  - Workflow: `build.yml`
- One test is still failing (`test_augmentations`) but this appears to be a pre-existing issue
- There are still 387 linting warnings from ruff (mostly line length) that can be addressed in future PRs