### PR TITLE
Set `/` redirect to `/latest/` in docs deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -51,8 +51,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash -l {0}
         run: |
-            mike deploy --update-aliases --allow-empty --push "${{ github.event.release.tag_name }}" latest
-
+            mike deploy --update-aliases --allow-empty "${{ github.event.release.tag_name }}" latest
+            mike set-default latest
+            mike push
+            
       - name: Build and upload docs (dev)
         if: ${{ github.event_name == 'push' }}
         env:


### PR DESCRIPTION
Close #133 

This pull request updates the GitHub Actions workflow for documentation deployment. So `dreem.sleap.ai` points at the latest documentation instead of v`0.0.1a1`


https://github.com/user-attachments/assets/60bf1b82-577b-41dd-9194-118c0c9ccc0d

