### PR TITLE
Non-max suppression for noisy detections

### DIFF
--- a/dreem/datasets/data_utils.py
+++ b/dreem/datasets/data_utils.py
@@ -254,6 +254,24 @@ def _pairwise_iou(boxes1: Boxes, boxes2: Boxes) -> torch.Tensor:
     return iou.nanmean(dim=-1)
 
 
+def nms(ious: torch.Tensor, threshold: float) -> list[int]:
+    """Non-maximum suppression.
+
+    Args:
+        ious: IoU matrix
+        threshold: threshold for non-maximum suppression
+    Returns:
+        list of indices of the boxes to keep
+    """
+    keep_inds = []
+    x, y = np.where(ious > threshold)
+    coords = np.stack([x, y], axis=-1)
+    self_mask = coords[:, 0] == coords[:, 1]  # diagonal elements are self-ious
+    coords = coords[~self_mask]
+
+    return coords
+
+
 def get_bbox(center: ArrayLike, size: int | tuple[int]) -> torch.Tensor:
     """Get a square bbox around a centroid coordinates.
 


### PR DESCRIPTION
The transformer is sensitive to detection noise, and duplicated instances in particular. Sometimes detection algorithms will predict multiple instances in the same location (have confirmed this with SLEAP with pose key points), and this causes ID switches as dreem does not do detection pruning during tracking. Adding NMS in the data loading step to remove duplicate detections as measured by IOU