### PR TITLE
Use hatch-vcs to derive version from Git tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,6 @@ agents/
 .cursor/
 run_tracker.py
 run_trainer.py
+
+# Auto-generated version file
+dreem/_version.py

--- a/dreem/__init__.py
+++ b/dreem/__init__.py
@@ -11,7 +11,7 @@ from dreem.models.global_tracking_transformer import GlobalTrackingTransformer
 from dreem.models.gtr_runner import GTRRunner
 from dreem.models.transformer import Transformer
 from dreem.models.visual_encoder import VisualEncoder
-from dreem.version import __version__
+from dreem._version import __version__
 
 __all__ = [
     "Tracker",

--- a/dreem/cli.py
+++ b/dreem/cli.py
@@ -22,7 +22,7 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 
-from dreem.version import __version__
+from dreem._version import __version__
 
 app = typer.Typer(
     name="dreem",

--- a/dreem/version.py
+++ b/dreem/version.py
@@ -1,3 +1,0 @@
-"""Central location for version information."""
-
-__version__ = "0.0.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,14 +70,17 @@ Repository = "https://github.com/talmolab/dreem"
 # Build system - using Hatchling
 # =============================================================================
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["dreem"]
 
 [tool.hatch.version]
-path = "dreem/version.py"
+source = "vcs"
+
+[tool.hatch.build.hooks.vcs]
+version-file = "dreem/_version.py"
 
 # =============================================================================
 # uv configuration for PyTorch with CUDA support

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,5 +4,6 @@ import dreem
 
 
 def test_version():
-    """Test version."""
-    assert dreem.__version__ == dreem.version.__version__
+    """Test version is available."""
+    assert dreem.__version__ is not None
+    assert isinstance(dreem.__version__, str)


### PR DESCRIPTION
## Summary
- Replace manual `version.py` with automatic version derivation from Git tags using `hatch-vcs`
- Prevents PyPI upload failures when the version file isn't updated before creating a release
- Version is now the single source of truth from Git tags (e.g., `v0.1.0` tag -> `0.1.0` version)

## Test plan
- [x] Verified `uv sync` regenerates `_version.py` correctly
- [x] Verified `dreem.__version__` imports successfully
- [x] Verified `pytest tests/test_version.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)