### PR TITLE
Fix packaging to include dreem/models directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,12 +136,10 @@ dmypy.json
 lightning_logs/
 outputs/
 logs/
-cli-refactor/
 wandb/
 
 # Local data/models/results
 data/
-models/
 results/
 *.ckpt
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,11 +56,6 @@ encoder = ["scikit-image"]  # Required for visual encoder functionality
 
 [project.scripts]
 dreem = "dreem.cli:app"
-# Legacy entry points (backwards compatibility)
-dreem-train = "dreem.training.train:run"
-dreem-eval = "dreem.inference.eval:run"
-dreem-track = "dreem.inference.track:run"
-dreem-visualize = "dreem.io.visualize:main"
 
 [project.urls]
 Homepage = "https://github.com/talmolab/dreem"


### PR DESCRIPTION
## Summary
- Remove `models/` from `.gitignore` which was causing Hatchling to exclude `dreem/models/` from the built wheel
- Remove legacy CLI entry points (`dreem-train`, `dreem-eval`, `dreem-track`, `dreem-visualize`) since the unified `dreem` command is now the only entry point

## Root Cause
The `.gitignore` had `models/` listed, which Hatchling respects when building packages. This caused the `dreem/models/` directory to be excluded from the wheel even though the files were tracked by git, resulting in `ModuleNotFoundError: No module named 'dreem.models'` when installing from PyPI.

## Test plan
- [ ] Merge PR and create new release tag
- [ ] Verify the published wheel includes `dreem/models/`
- [ ] Test `dreem track --help` works after installing from PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)